### PR TITLE
Fix immutable dates causing issues in the Control Panel

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\Runway\Http\Controllers;
 
+use Carbon\CarbonInterface;
 use DoubleThreeDigital\Runway\Http\Requests\CreateRequest;
 use DoubleThreeDigital\Runway\Http\Requests\EditRequest;
 use DoubleThreeDigital\Runway\Http\Requests\IndexRequest;
@@ -126,7 +127,7 @@ class ResourceController extends CpController
         foreach ($blueprintFieldKeys as $fieldKey) {
             $value = $record->{$fieldKey};
 
-            if ($value instanceof \Carbon\CarbonInterface) {
+            if ($value instanceof CarbonInterface) {
                 $format = $defaultFormat = 'Y-m-d H:i';
 
                 if ($field = $resource->blueprint()->field($fieldKey)) {


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

This pull request fixes an issue where you'd get a `Trailing data` error from Carbon if you're casting some sort of date column to immutable.

Instead of checking against just the `Carbon\Carbon` instance, I'm now checking against the `Carbon\CarbonInterface` which will cover both immutable/mutable cases. The Runway tag was already using the `CarbonInterface` method.

## Related Issues

<!-- 
  Does this PR fix any open issues? 
  -- If so, please do something like this: 'Closes #1'
-->

Fixes #89
