### PR TITLE
[6.x] Fix listable fields state

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -118,7 +118,17 @@ class Resource
 
     public function titleField()
     {
-        return $this->config->get('title_field', $this->listableColumns()->first());
+        if ($titleField = $this->config()->get('title_field')) {
+            return $titleField;
+        }
+
+        return $this->listableColumns()
+            ->reject(function ($handle) {
+                $field = $this->blueprint()->field($handle);
+
+                return $field->get('listable') && $field->get('listable') === 'hidden';
+            })
+            ->first();
     }
 
     /**
@@ -165,7 +175,7 @@ class Resource
     public function listableColumns(): Collection
     {
         return $this->blueprint()->fields()->all()
-            ->filter(fn (Field $field) => $field->isVisibleOnListing())
+            ->filter(fn (Field $field) => $field->isListable())
             ->map->handle()
             ->values();
     }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -185,6 +185,7 @@ class ResourceTest extends TestCase
         $this->assertEquals([
             'title',
             'summary',
+            'body',
             'seo_title',
             'seo_description',
         ], $resource->listableColumns()->toArray());


### PR DESCRIPTION
This pull request fixes an issue I noticed while spinning up a fresh Runway install. 

The fields in the blueprint builder are automatically set to `listable: hidden` and if you visit the listing table without any visible columns, you'd get an error.

This should hopefully fix that issue and mirror the changes made in #393 for v5.x.