### PR TITLE
[6.x] Fix nav icons not displaying

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -69,7 +69,7 @@ class Resource
             return file_get_contents(__DIR__.'/../resources/svg/database.svg');
         }
 
-        return $this->config->has('cp_icon');
+        return $this->config->get('cp_icon');
     }
 
     public function hidden(): bool


### PR DESCRIPTION
Fixes an issue with nav icons not displaying. Currently, v6 is using a `has` method both for the initial check _**and**_ to generate the actual return value, so all icons come back as `1`, which of course isn't a valid icon string.