### PR TITLE
[5.x] Include Model ID in Publish Form values

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -238,7 +238,7 @@ class ResourceController extends CpController
             ]),
             'resource' => $resource,
             'blueprint' => $blueprint->toPublishArray(),
-            'values' => $fields->values(),
+            'values' => $fields->values()->merge(['id' => $record->getKey()]),
             'meta' => $fields->meta(),
             'permalink' => $resource->hasRouting()
                 ? $record->uri()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -83,7 +83,7 @@ abstract class TestCase extends OrchestraTestCase
         foreach ($configs as $config) {
             $app['config']->set(
                 "statamic.$config",
-                require(__DIR__."/../vendor/statamic/cms/config/{$config}.php")
+                require (__DIR__."/../vendor/statamic/cms/config/{$config}.php")
             );
         }
 


### PR DESCRIPTION
This pull request passes along the Model ID in the `values` that get passed along to the publish form so it exists in the Vuex store.

Fixes duncanmcclean/simple-commerce#966