### PR TITLE
[6.x] Fix model accessors not being augmented

### DIFF
--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Data;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Statamic\Data\AbstractAugmented;
@@ -131,6 +132,10 @@ class AugmentedModel extends AbstractAugmented
                     );
                 })
                 ->toArray();
+        }
+
+        if ($value instanceof Attribute) {
+            $value = ($value->get)();
         }
 
         return new Value(

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -60,4 +60,14 @@ class AugmentedModelTest extends TestCase
         $this->assertEquals('Alternative Title...', $augmented->get('values')->value()['alt_title']->value());
         $this->assertEquals('<p>This is a <strong>great</strong> post! You should <em>read</em> it.</p>', trim($augmented->get('values')->value()['alt_body']->value()));
     }
+
+    /** @test */
+    public function it_gets_value_from_model_accessor()
+    {
+        $post = Post::factory()->create();
+
+        $augmented = new AugmentedModel($post);
+
+        $this->assertEquals('This is an excerpt.', $augmented->get('excerpt')->value());
+    }
 }

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Tests\Fixtures\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use StatamicRadPack\Runway\Routing\Traits\RunwayRoutes;
@@ -42,9 +43,13 @@ class Post extends Model
         return $this->belongsTo(Author::class);
     }
 
-    public function getExcerptAttribute()
+    public function excerpt(): Attribute
     {
-        return 'This is an excerpt.';
+        return Attribute::make(
+            get: function () {
+                return 'This is an excerpt.';
+            }
+        );
     }
 
     protected static function newFactory()


### PR DESCRIPTION
This pull request fixes an issue where model accessors aren't being augmented after the augmentation changes in #354.

Fixes #404.