### PR TITLE
[6.x] Fix saving models in relationship stacks

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -32,7 +32,7 @@ class BaseFieldtype extends Relationship
         'initialValues' => 'values',
         'initialMeta' => 'meta',
         'initialTitle' => 'title',
-        'action' => 'action',
+        'initialActions' => 'actions',
         'method' => 'method',
         'resourceHasRoutes' => 'resourceHasRoutes',
         'permalink' => 'permalink',


### PR DESCRIPTION
This pull request fixes an issue when trying to save models via Runway's Relationship Fieldtypes. 

After changes to the way publish form actions worked in #400, I didn't tweak `$formComponentProps` in the `BaseFieldtype` for the renamed prop to be passed along to the "inline publish form".

Fixes #406.