### PR TITLE
[6.x] Documentation Changes for Blueprints, Index, and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ return [
 In addition to front-end routing, you may also use Runway's tag to loop through your models and display the results. The tag supports filtering, using Eloquent scopes and sorting.
 
 ```antlers
-{{ runway:products }}
+{{ runway:product }}
     <h2>{{ name }}</h2>
     <p>Price: {{ price }}</p>
-{{ /runway:products }}
+{{ /runway:product }}
 ```
 
 -   [Review documentation](https://runway.duncanmcclean.com/templating)

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -143,7 +143,5 @@ Then, in your user blueprint, you'd set the field's visibility to "Computed":
 ![Field's visibility set to computed](/img/runway/field-visibility-computed.png)
 
 :::note Note!
-Please note in runway, the accessor must be defined as a `public function`.
-In the [Laravel Docs](https://laravel.com/docs/10.x/eloquent-mutators#accessors-and-mutators), accessors are defined as a `protected function`.
-This will result in a `BadMethodCallException` if you call protected computed field.
+It's worth noting, Runway requires any accessors to be `public` functions, otherwise the attributes won't be augmentable.
 :::

--- a/docs/blueprints.md
+++ b/docs/blueprints.md
@@ -141,3 +141,9 @@ public function fullName(): Attribute
 Then, in your user blueprint, you'd set the field's visibility to "Computed":
 
 ![Field's visibility set to computed](/img/runway/field-visibility-computed.png)
+
+:::note Note!
+Please note in runway, the accessor must be defined as a `public function`.
+In the [Laravel Docs](https://laravel.com/docs/10.x/eloquent-mutators#accessors-and-mutators), accessors are defined as a `protected function`.
+This will result in a `BadMethodCallException` if you call protected computed field.
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,10 +32,10 @@ return [
 In addition to front-end routing, you may also use Runway's tag to loop through your models and display the results. The tag supports filtering, using Eloquent scopes and sorting.
 
 ```antlers
-{{ runway:products }}
+{{ runway:product }}
     <h2>{{ name }}</h2>
     <p>Price: {{ price }}</p>
-{{ /runway:products }}
+{{ /runway:product }}
 ```
 
 -   [Review documentation](https://runway.duncanmcclean.com/templating)


### PR DESCRIPTION
Blueprints: Added Note to call attention to the accessor being defined as a public function, which differs from the Laravel docs example.

Index & Readme: Changed products to product in the example to reflect the singular nature of the handle for other resources used in the documentation.