### PR TITLE
[6.x] Add progress bar to rebuild URI cache command

### DIFF
--- a/src/Console/Commands/RebuildUriCache.php
+++ b/src/Console/Commands/RebuildUriCache.php
@@ -57,6 +57,7 @@ class RebuildUriCache extends Command
 
         Runway::allResources()
             ->each(function (Resource $resource) {
+                $this->newLine(2);
                 $this->info("Building {$resource->name()} URIs");
 
                 if (! $resource->hasRouting()) {
@@ -65,9 +66,7 @@ class RebuildUriCache extends Command
                     return;
                 }
 
-                $resource->model()->all()->each(function ($model) use ($resource) {
-                    $this->line("{$resource->name()}: {$model->{$resource->primaryKey()}}");
-
+                $this->withProgressBar($resource->model()->all(), function ($model) use ($resource) {
                     $uri = (new Parser())
                         ->parse($resource->route(), $model->toAugmentedArray())
                         ->__toString();


### PR DESCRIPTION
This pull request adds a progress bar to the `runway:rebuild-uri-cache` command to make it look a little more beautiful.

![CleanShot 2024-01-25 at 12 27 13](https://github.com/statamic-rad-pack/runway/assets/19637309/d92c0fa0-4da2-4bc0-9ba4-ea8366f8b2c9)
