### PR TITLE
[6.x] Adding support for query expressions in the 'order_by' config option

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway;
 
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
@@ -106,7 +107,7 @@ class Resource
         return $this->config->get('read_only', false);
     }
 
-    public function orderBy(): string
+    public function orderBy(): string|Expression
     {
         return $this->config->get('order_by', $this->primaryKey());
     }


### PR DESCRIPTION
This update provides support for providing a query expression to the `order_by` configuration option.

Here is an example of a potential use-case:

```php
'order_by' => (new \Illuminate\Database\Query\Expression('IFNULL(finalised_at, updated_at)')),
```