### PR TITLE
[6.x] Fix value in HasMany fieldtype being overwritten when opened in inline publish form

### DIFF
--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -288,7 +288,7 @@ export default {
                 tab.sections.forEach((section) => {
                     section.fields
                         .filter((field) => {
-                            return field.type === 'belongs_to' || field.resource === window.Runway.currentResource;
+                            return field.type === 'belongs_to' && field.resource === window.Runway.currentResource;
                         })
                         .forEach((field) => {
                             let alreadyExists = this.values[field.handle].includes(window.Runway.currentModel.id)


### PR DESCRIPTION
This pull request fixes an issue where Has Many relationship fields were being overwritten unintentionally when the publish form was opened in an inline stack.

It looks like this was caused by refactoring in 54c79d6, where `&&` was swapped with a `||` causing the pre-filling logic to be run when it shouldn't be.

Fixes #426.