### PR TITLE
[6.x] Fix infinite loop caused by slug method

### DIFF
--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace StatamicRadPack\Runway\Routing;
+
+use Closure;
+use Statamic\Contracts\Routing\UrlBuilder;
+use Statamic\Facades\URL;
+use Statamic\Support\Str;
+
+/**
+ * This class is a direct copy of the Statamic\Routing\Routable trait,
+ * just without the `slug` method & property which conflict with Eloquent
+ * attributes of the same name.
+ *
+ * See: https://github.com/statamic-rad-pack/runway/issues/420
+ */
+trait Routable
+{
+    abstract public function route();
+
+    abstract public function routeData();
+
+    public function uri()
+    {
+        if (! $route = $this->route()) {
+            return null;
+        }
+
+        return app(UrlBuilder::class)->content($this)->build($route);
+    }
+
+    public function url()
+    {
+        if ($this->isRedirect()) {
+            return $this->redirectUrl();
+        }
+
+        return $this->urlWithoutRedirect();
+    }
+
+    public function urlWithoutRedirect()
+    {
+        if (! $url = $this->absoluteUrlWithoutRedirect()) {
+            return null;
+        }
+
+        return URL::makeRelative($url);
+    }
+
+    public function absoluteUrl()
+    {
+        if ($this->isRedirect()) {
+            return $this->absoluteRedirectUrl();
+        }
+
+        return $this->absoluteUrlWithoutRedirect();
+    }
+
+    public function absoluteUrlWithoutRedirect()
+    {
+        return $this->makeAbsolute($this->uri());
+    }
+
+    public function isRedirect()
+    {
+        return ($url = $this->redirectUrl())
+            && $url !== 404;
+    }
+
+    public function redirectUrl()
+    {
+        if ($redirect = $this->value('redirect')) {
+            return (new \Statamic\Routing\ResolveRedirect)($redirect, $this);
+        }
+    }
+
+    public function absoluteRedirectUrl()
+    {
+        return $this->makeAbsolute($this->redirectUrl());
+    }
+
+    private function makeAbsolute($url)
+    {
+        if (! $url) {
+            return null;
+        }
+
+        if (! Str::startsWith($url, '/')) {
+            return $url;
+        }
+
+        $url = vsprintf('%s/%s', [
+            rtrim($this->site()->absoluteUrl(), '/'),
+            ltrim($url, '/'),
+        ]);
+
+        return $url === '/' ? $url : rtrim($url, '/');
+    }
+}

--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -2,7 +2,6 @@
 
 namespace StatamicRadPack\Runway\Routing;
 
-use Closure;
 use Statamic\Contracts\Routing\UrlBuilder;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;

--- a/src/Routing/Routable.php
+++ b/src/Routing/Routable.php
@@ -11,7 +11,7 @@ use Statamic\Support\Str;
  * just without the `slug` method & property which conflict with Eloquent
  * attributes of the same name.
  *
- * See: https://github.com/statamic-rad-pack/runway/issues/420
+ * See: https://github.com/statamic-rad-pack/runway/pull/429
  */
 trait Routable
 {

--- a/src/Routing/Traits/RunwayRoutes.php
+++ b/src/Routing/Traits/RunwayRoutes.php
@@ -4,10 +4,10 @@ namespace StatamicRadPack\Runway\Routing\Traits;
 
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Str;
-use Statamic\Routing\Routable;
 use Statamic\StaticCaching\Cacher;
 use Statamic\Support\Arr;
 use Statamic\View\Antlers\Parser;
+use StatamicRadPack\Runway\Routing\Routable;
 use StatamicRadPack\Runway\Routing\RoutingModel;
 use StatamicRadPack\Runway\Routing\RunwayUri;
 use StatamicRadPack\Runway\Runway;
@@ -25,11 +25,6 @@ trait RunwayRoutes
         $this->routingModel = new RoutingModel($this);
 
         return $this->routingModel;
-    }
-
-    public function slug(): string
-    {
-        return $this->getAttribute('slug');
     }
 
     public function route(): ?string


### PR DESCRIPTION
This pull request fixes an issue where you'd end up in an infinite loop when getting/setting the `slug` attribute on a model with the `RunwayRoutes` trait.

This was happening because Runway's `RunwayRoutes` trait contains a [`slug()`](https://github.com/statamic-rad-pack/runway/blob/6.x/src/Routing/Traits/RunwayRoutes.php#L30) method (which is required by Statamic's routing contracts).

The `slug` method attempts to get the current slug for the model, using Eloquent's [`getAttribute`](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L429) method. Since, it can't find a value for `slug` on the model, it finds that there's a `slug()` method on the model and tries to use that instead. That's where the infinite loop happens.

This PR fixes that issue by copying Statamic's `Routable` trait and removing the `slug` method & property. This seems to fix the issue and doesn't break anything routing-wise from what I can tell. 

Fixes #420.