### PR TITLE
[6.x] Removed return type declaration from the 'Resource::orderBy()' method

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -106,7 +106,7 @@ class Resource
         return $this->config->get('read_only', false);
     }
 
-    public function orderBy(): string
+    public function orderBy()
     {
         return $this->config->get('order_by', $this->primaryKey());
     }


### PR DESCRIPTION
This is to maintain compatibility with Laravel's `\Illuminate\Database\Query\Builder::orderBy($column, $direction = 'asc')` type declaration in a non-breaking way.

Other solutions, such as using the `runwayListing` scope, are all potentially breaking changes and require a significant amount more effort to implement.