### PR TITLE
[6.x] Allow runwayListing scope to modify the order

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -85,10 +85,12 @@ class BaseFieldtype extends Relationship
     {
         $resource = Runway::findResource($this->config('resource'));
 
-        $query = $resource->model()->orderBy($resource->orderBy(), $resource->orderByDirection());
+        $query = $resource->model()->newQuery();
 
         $query->when($query->hasNamedScope('runwayListing'), fn ($query) => $query->runwayListing());
         $query->when($request->search, fn ($query) => $query->runwaySearch($request->search));
+
+        $query->unless($query->getQuery()->orders, fn ($query) => $query->orderBy($resource->orderBy(), $resource->orderByDirection()));
 
         $items = $request->boolean('paginate', true)
             ? $query->paginate()

--- a/src/Http/Controllers/CP/ResourceListingController.php
+++ b/src/Http/Controllers/CP/ResourceListingController.php
@@ -21,20 +21,16 @@ class ResourceListingController extends CpController
             abort(403);
         }
 
-        $sortField = $request->input('sort', $resource->orderBy());
-        $sortDirection = $request->input('order', $resource->orderByDirection());
-
-        $query = $resource->model()
-            ->with($resource->eagerLoadingRelationships());
+        $query = $resource->model()->with($resource->eagerLoadingRelationships());
 
         $query->when($query->hasNamedScope('runwayListing'), fn ($query) => $query->runwayListing());
         $query->when($request->search, fn ($query) => $query->runwaySearch($request->search));
 
-        $query->when($query->getQuery()->orders, function ($query) use ($request, $sortField, $sortDirection) {
+        $query->when($query->getQuery()->orders, function ($query) use ($request) {
             if ($request->input('sort')) {
-                $query->reorder($sortField, $sortDirection);
+                $query->reorder($request->input('sort'), $request->input('order'));
             }
-        }, fn ($query) => $query->orderBy($sortField, $sortDirection));
+        }, fn ($query) => $query->orderBy($resource->orderBy(), $resource->orderByDirection()));
 
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
             'resource' => $resource->handle(),

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use Statamic\Facades\Blink;
 use Statamic\Fields\Field;
 use Statamic\Http\Requests\FilteredRequest;
 use StatamicRadPack\Runway\Fieldtypes\BelongsToFieldtype;
@@ -97,6 +98,46 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->all()[0]['title'], 'Scully');
         $this->assertEquals($getIndexItems->all()[1]['title'], 'Jake Peralta');
         $this->assertEquals($getIndexItems->all()[2]['title'], 'Amy Santiago');
+    }
+
+    /** @test */
+    public function can_get_index_items_in_order_from_runway_listing_scope()
+    {
+        Author::factory()->create(['name' => 'Scully']);
+        Author::factory()->create(['name' => 'Jake Peralta']);
+        Author::factory()->create(['name' => 'Amy Santiago']);
+
+        Blink::put('runway_listing_scope_order_by', ['name', 'desc']);
+
+        $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false]));
+
+        $this->assertIsObject($getIndexItems);
+        $this->assertTrue($getIndexItems instanceof Collection);
+        $this->assertEquals($getIndexItems->count(), 3);
+
+        $this->assertEquals($getIndexItems->all()[0]['title'], 'Scully');
+        $this->assertEquals($getIndexItems->all()[1]['title'], 'Jake Peralta');
+        $this->assertEquals($getIndexItems->all()[2]['title'], 'Amy Santiago');
+    }
+
+    /** @test */
+    public function can_get_index_items_in_order_from_runway_listing_scope_when_user_defines_an_order()
+    {
+        Author::factory()->create(['name' => 'Scully']);
+        Author::factory()->create(['name' => 'Jake Peralta']);
+        Author::factory()->create(['name' => 'Amy Santiago']);
+
+        Blink::put('runway_listing_scope_order_by', ['name', 'desc']);
+
+        $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false, 'sort' => 'name', 'order' => 'asc']));
+
+        $this->assertIsObject($getIndexItems);
+        $this->assertTrue($getIndexItems instanceof Collection);
+        $this->assertEquals($getIndexItems->count(), 3);
+
+        $this->assertEquals($getIndexItems->all()[0]['title'], 'Amy Santiago');
+        $this->assertEquals($getIndexItems->all()[1]['title'], 'Jake Peralta');
+        $this->assertEquals($getIndexItems->all()[2]['title'], 'Scully');
     }
 
     /** @test */

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -107,7 +107,7 @@ class BelongsToFieldtypeTest extends TestCase
         Author::factory()->create(['name' => 'Jake Peralta']);
         Author::factory()->create(['name' => 'Amy Santiago']);
 
-        Blink::put('runway_listing_scope_order_by', ['name', 'desc']);
+        Blink::put('RunwayListingScopeOrderBy', ['name', 'desc']);
 
         $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false]));
 
@@ -127,7 +127,7 @@ class BelongsToFieldtypeTest extends TestCase
         Author::factory()->create(['name' => 'Jake Peralta']);
         Author::factory()->create(['name' => 'Amy Santiago']);
 
-        Blink::put('runway_listing_scope_order_by', ['name', 'desc']);
+        Blink::put('RunwayListingScopeOrderBy', ['name', 'desc']);
 
         $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false, 'sort' => 'name', 'order' => 'asc']));
 

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -143,6 +143,46 @@ class HasManyFieldtypeTest extends TestCase
     }
 
     /** @test */
+    public function can_get_index_items_in_order_from_runway_listing_scope()
+    {
+        Post::factory()->create(['title' => 'Arnold A']);
+        Post::factory()->create(['title' => 'Richard B']);
+        Post::factory()->create(['title' => 'Graham C']);
+
+        Blink::put('runway_listing_scope_order_by', ['title', 'asc']);
+
+        $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false]));
+
+        $this->assertIsObject($getIndexItems);
+        $this->assertTrue($getIndexItems instanceof Collection);
+        $this->assertEquals($getIndexItems->count(), 3);
+
+        $this->assertEquals($getIndexItems->all()[0]['title'], 'Arnold A');
+        $this->assertEquals($getIndexItems->all()[1]['title'], 'Graham C');
+        $this->assertEquals($getIndexItems->all()[2]['title'], 'Richard B');
+    }
+
+    /** @test */
+    public function can_get_index_items_in_order_from_runway_listing_scope_when_user_defines_an_order()
+    {
+        Post::factory()->create(['title' => 'Arnold A']);
+        Post::factory()->create(['title' => 'Richard B']);
+        Post::factory()->create(['title' => 'Graham C']);
+
+        Blink::put('runway_listing_scope_order_by', ['title', 'asc']);
+
+        $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false, 'sort' => 'title', 'order' => 'desc']));
+
+        $this->assertIsObject($getIndexItems);
+        $this->assertTrue($getIndexItems instanceof Collection);
+        $this->assertEquals($getIndexItems->count(), 3);
+
+        $this->assertEquals($getIndexItems->all()[0]['title'], 'Richard B');
+        $this->assertEquals($getIndexItems->all()[1]['title'], 'Graham C');
+        $this->assertEquals($getIndexItems->all()[2]['title'], 'Arnold A');
+    }
+
+    /** @test */
     public function can_get_index_items_and_search()
     {
         $author = Author::factory()->create();

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -149,7 +149,7 @@ class HasManyFieldtypeTest extends TestCase
         Post::factory()->create(['title' => 'Richard B']);
         Post::factory()->create(['title' => 'Graham C']);
 
-        Blink::put('runway_listing_scope_order_by', ['title', 'asc']);
+        Blink::put('RunwayListingScopeOrderBy', ['title', 'asc']);
 
         $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false]));
 
@@ -169,7 +169,7 @@ class HasManyFieldtypeTest extends TestCase
         Post::factory()->create(['title' => 'Richard B']);
         Post::factory()->create(['title' => 'Graham C']);
 
-        Blink::put('runway_listing_scope_order_by', ['title', 'asc']);
+        Blink::put('RunwayListingScopeOrderBy', ['title', 'asc']);
 
         $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false, 'sort' => 'title', 'order' => 'desc']));
 

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -85,8 +85,6 @@ class ResourceListingControllerTest extends TestCase
     /** @test */
     public function listing_rows_are_ordered_from_runway_listing_scope()
     {
-        Runway::discoverResources();
-
         $user = User::make()->makeSuper()->save();
         $posts = Post::factory()->count(2)->create();
 
@@ -115,8 +113,6 @@ class ResourceListingControllerTest extends TestCase
     /** @test */
     public function listing_rows_arent_ordered_from_runway_listing_scope_when_user_defines_an_order()
     {
-        Runway::discoverResources();
-
         $user = User::make()->makeSuper()->save();
         $posts = Post::factory()->count(2)->create();
 

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -88,7 +88,7 @@ class ResourceListingControllerTest extends TestCase
         $user = User::make()->makeSuper()->save();
         $posts = Post::factory()->count(2)->create();
 
-        Blink::put('runway_listing_scope_order_by', ['id', 'desc']);
+        Blink::put('RunwayListingScopeOrderBy', ['id', 'desc']);
 
         $this
             ->actingAs($user)
@@ -116,7 +116,7 @@ class ResourceListingControllerTest extends TestCase
         $user = User::make()->makeSuper()->save();
         $posts = Post::factory()->count(2)->create();
 
-        Blink::put('runway_listing_scope_order_by', ['id', 'desc']);
+        Blink::put('RunwayListingScopeOrderBy', ['id', 'desc']);
 
         $this
             ->actingAs($user)

--- a/tests/__fixtures__/app/Models/Author.php
+++ b/tests/__fixtures__/app/Models/Author.php
@@ -4,6 +4,7 @@ namespace StatamicRadPack\Runway\Tests\Fixtures\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Statamic\Facades\Blink;
 use StatamicRadPack\Runway\Tests\Fixtures\Database\Factories\AuthorFactory;
 use StatamicRadPack\Runway\Traits\HasRunwayResource;
 
@@ -23,6 +24,13 @@ class Author extends Model
     public function pivottedPosts()
     {
         return $this->belongsToMany(Post::class, 'post_author');
+    }
+
+    public function scopeRunwayListing($query)
+    {
+        if ($params = Blink::get('runway_listing_scope_order_by')) {
+            $query->orderBy($params[0], $params[1]);
+        }
     }
 
     protected static function newFactory()

--- a/tests/__fixtures__/app/Models/Author.php
+++ b/tests/__fixtures__/app/Models/Author.php
@@ -28,7 +28,7 @@ class Author extends Model
 
     public function scopeRunwayListing($query)
     {
-        if ($params = Blink::get('runway_listing_scope_order_by')) {
+        if ($params = Blink::get('RunwayListingScopeOrderBy')) {
             $query->orderBy($params[0], $params[1]);
         }
     }

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -5,6 +5,7 @@ namespace StatamicRadPack\Runway\Tests\Fixtures\Models;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Statamic\Facades\Blink;
 use StatamicRadPack\Runway\Routing\Traits\RunwayRoutes;
 use StatamicRadPack\Runway\Tests\Fixtures\Database\Factories\PostFactory;
 use StatamicRadPack\Runway\Traits\HasRunwayResource;
@@ -36,6 +37,13 @@ class Post extends Model
     {
         if ($smth === 'idoo') {
             $query->whereIn('title', ['Apple']);
+        }
+    }
+
+    public function scopeRunwayListing($query)
+    {
+        if ($params = Blink::get('runway_listing_scope_order_by')) {
+            $query->orderBy($params[0], $params[1]);
         }
     }
 

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -42,7 +42,7 @@ class Post extends Model
 
     public function scopeRunwayListing($query)
     {
-        if ($params = Blink::get('runway_listing_scope_order_by')) {
+        if ($params = Blink::get('RunwayListingScopeOrderBy')) {
             $query->orderBy($params[0], $params[1]);
         }
     }


### PR DESCRIPTION
This PR moves the orderBy clause to after runwayListing has been run, and make it conditional on whether an orderBy clause already exists.

Let me know where to make a test for this as I cant see any coverage of the scopes?

Replaces https://github.com/statamic-rad-pack/runway/pull/433