### PR TITLE
[6.x] Improve augmentation of relationships

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -4,7 +4,6 @@ namespace StatamicRadPack\Runway\Fieldtypes;
 
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Statamic\CP\Column;

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -12,6 +12,7 @@ use Statamic\Facades\Blink;
 use Statamic\Facades\Parse;
 use Statamic\Fieldtypes\Relationship;
 use StatamicRadPack\Runway\Query\Scopes\Filters\Fields\Models;
+use StatamicRadPack\Runway\Resource;
 use StatamicRadPack\Runway\Runway;
 
 class BaseFieldtype extends Relationship
@@ -183,103 +184,55 @@ class BaseFieldtype extends Relationship
     {
         $resource = Runway::findResource($this->config('resource'));
 
-        if ($values instanceof Relation) {
-            $results = $values
-                ->get()
-                ->map->toAugmentedArray()
-                ->filter();
-
-            if ($this->config('max_items') === 1) {
-                return $results->first();
-            }
-
-            return $results;
-        }
-
-        $values = Arr::wrap($values);
-
-        $results = collect($values)
-            ->map(function ($item) use ($resource) {
-                if (is_array($item) && Arr::has($item, $resource->primaryKey())) {
-                    return Arr::get($item, $resource->primaryKey());
-                }
-
-                return $item;
-            })
+        $results = $this->getAugmentableModels($resource, $values)
             ->map(function ($model) use ($resource) {
-                if (! $model instanceof Model) {
-                    $eagerLoadingRelationships = collect($this->config('with') ?? [])->join(',');
+                return Blink::once("Runway::FieldtypeAugment::{$resource->handle()}_{$model->{$resource->primaryKey()}}", function () use ($model) {
+                    return $model->toAugmentedArray();
+                });
+            });
 
-                    $model = Blink::once("Runway::{$this->config('resource')}::{$model}}::{$eagerLoadingRelationships}", function () use ($resource, $model) {
-                        return $resource->model()
-                            ->when($this->config('with'), function ($query) {
-                                $query->with(Arr::wrap($this->config('with')));
-                            })
-                            ->firstWhere($resource->primaryKey(), $model);
-                    });
-                }
-
-                if (! $model) {
-                    return null;
-                }
-
-                return $model->toAugmentedArray();
-            })
-            ->filter();
-
-        if ($this->config('max_items') === 1) {
-            return $results->first();
-        }
-
-        return $results->toArray();
+        return $this->config('max_items') === 1
+            ? $results->first()
+            : $results->toArray();
     }
 
     public function shallowAugment($values)
     {
         $resource = Runway::findResource($this->config('resource'));
 
-        if ($values instanceof Relation) {
-            $results = $values
-                ->get()
-                ->map->toShallowAugmentedArray()
-                ->filter();
+        $results = $this->getAugmentableModels($resource, $values)
+            ->map(function ($model) use ($resource) {
+                return Blink::once("Runway::FieldtypeShallowAugment::{$resource->handle()}_{$model->{$resource->primaryKey()}}", function () use ($model) {
+                    return $model->toShallowAugmentedArray();
+                });
+            });
 
-            if ($this->config('max_items') === 1) {
-                return $results->first();
-            }
+        return $this->config('max_items') === 1
+            ? $results->first()
+            : $results->toArray();
+    }
 
-            return $results;
-        }
-
-        $values = Arr::wrap($values);
-
-        $results = collect($values)
+    protected function getAugmentableModels(Resource $resource, $values): Collection
+    {
+        return collect($values)
             ->map(function ($model) use ($resource) {
                 if (! $model instanceof Model) {
-                    $eagerLoadingRelations = collect($this->config('with') ?? [])->join(',');
+                    $eagerLoadingRelationships = collect($this->config('with') ?? [])->join(',');
 
-                    $model = Blink::once("Runway::{$this->config('resource')}::{$model}}::{$eagerLoadingRelations}", function () use ($resource, $model) {
+                    return Blink::once("Runway::Model::{$this->config('resource')}_{$model}}::{$eagerLoadingRelationships}", function () use ($resource, $model) {
                         return $resource->model()
-                            ->when($this->config('with'), function ($query) {
-                                $query->with(Arr::wrap($this->config('with')));
-                            })
+                            ->when(
+                                $this->config('with'),
+                                fn ($query) => $query->with(Arr::wrap($this->config('with'))),
+                                fn ($query) => $query->with($resource->eagerLoadingRelationships())
+                            )
                             ->firstWhere($resource->primaryKey(), $model);
                     });
                 }
 
-                if (! $model) {
-                    return null;
-                }
-
-                return $model->toShallowAugmentedArray();
+                return $model;
             })
             ->filter();
-
-        if ($this->config('max_items') === 1) {
-            return $results->first();
-        }
-
-        return $results->toArray();
     }
 
     protected function getColumns()

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -27,7 +27,12 @@ class RunwayTag extends Tags
             );
         }
 
-        $query = $resource->model()->query();
+        $query = $resource->model()->query()
+            ->when(
+                $this->params->get('with'),
+                fn ($query) => $query->with(explode('|', (string) $this->params->get('with'))),
+                fn ($query) => $query->with($resource->eagerLoadingRelationships())
+            );
 
         if ($select = $this->params->get('select')) {
             $query->select(explode(',', (string) $select));
@@ -73,10 +78,6 @@ class RunwayTag extends Tags
             } else {
                 $query->where($key, $value);
             }
-        }
-
-        if ($with = $this->params->get('with')) {
-            $query->with(explode('|', (string) $with));
         }
 
         if ($this->params->has('sort') && ! empty($this->params->get('sort'))) {


### PR DESCRIPTION
This pull request refactors how Eloquent Relationships are augmented to improve performance and prevent as many duplicate queries, like seen in #430. 

Changes include:

* Instead of a `HasMany`/`BelongsTo` relationship instance being passed to the augmentation methods, we now pass an `Eloquent\Collection` instance. 
    * Essentially, we're now doing `$model->relationship` instead of `$model->relationship()`. This change also lets us take advantage of eager loading for the related models.
* I've refactored the augmentation methods in the `BaseFieldtype` to simplify it, now it only needs to accept an `Eloquent\Collection` or an array of IDs (in the case the fieldtype is being used on entries). 
* The `runwayUri` relationship no longer gets augmented.
    * There's no reason for the `runwayUri` relation to be augmented in the first place so it's a quick win 🚀 
* Previously, the `{{ runway }}` tag wasn't eager loading any relationships, unless you were providing the relationships to be eager loaded yourself. 
    * Now, similar to the listing table in the CP, Runway will automatically eager load models based on the relationship fields you have configured in your resource blueprint.

## Testing
On my local sandbox, I managed to reduce the number of total queries for index pages (which use the `{{ runway }}` tag) down from a couple hundred to 3 queries.

Then, in [the demo site](https://github.com/mefenlon/statamic-playground.git) provided in #430, I've managed to get rid of the duplicate queries & reduce the total number of queries down to 108, which is more reasonable than a couple thousand. 

---

Closes #430.