### PR TITLE
[6.x] Bring back handling user selection when there is no other orderby

### DIFF
--- a/src/Http/Controllers/CP/ResourceListingController.php
+++ b/src/Http/Controllers/CP/ResourceListingController.php
@@ -30,7 +30,7 @@ class ResourceListingController extends CpController
             if ($request->input('sort')) {
                 $query->reorder($request->input('sort'), $request->input('order'));
             }
-        }, fn ($query) => $query->orderBy($resource->orderBy(), $resource->orderByDirection()));
+        }, fn ($query) => $query->orderBy($request->input('sort', $resource->orderBy()), $request->input('order', $resource->orderByDirection())));
 
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
             'resource' => $resource->handle(),

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -139,6 +139,32 @@ class ResourceListingControllerTest extends TestCase
     }
 
     /** @test */
+    public function listing_rows_are_ordered_when_user_defines_an_order_and_no_runway_listing_scope_order_exists()
+    {
+        $user = User::make()->makeSuper()->save();
+        $posts = Post::factory()->count(2)->create();
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('runway.listing-api', ['resource' => 'post', 'sort' => 'id', 'order' => 'desc']))
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    [
+                        'title' => $posts[1]->title,
+                        'edit_url' => "http://localhost/cp/runway/post/{$posts[1]->id}",
+                        'id' => $posts[1]->id,
+                    ],
+                    [
+                        'title' => $posts[0]->title,
+                        'edit_url' => "http://localhost/cp/runway/post/{$posts[0]->id}",
+                        'id' => $posts[0]->id,
+                    ],
+                ],
+            ]);
+    }
+
+    /** @test */
     public function can_search()
     {
         $user = User::make()->makeSuper()->save();


### PR DESCRIPTION
This [change](https://github.com/statamic-rad-pack/runway/pull/434/commits/0321d67eba5b65089926e1f52df56117aa49fa82) reverted some of the logic for handling user selected sorting.

This PR brings it back.

Closes #437 