### PR TITLE
[6.x] Wrap values when getting augmentable models

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -213,7 +213,7 @@ class BaseFieldtype extends Relationship
 
     protected function getAugmentableModels(Resource $resource, $values): Collection
     {
-        return collect($values)
+        return collect(Arr::wrap($values))
             ->map(function ($model) use ($resource) {
                 if (! $model instanceof Model) {
                     $eagerLoadingRelationships = collect($this->config('with') ?? [])->join(',');


### PR DESCRIPTION
This pull request fixes an issue where `$values` was an Eloquent `Model` instance. However, when it was being converted into a Illuminate `Collection`, it ended up turning into an array like this:

```
[
  'id' => 1,
  'name' => 'John Doe',
  'email' => 'john.doe@example.com',
  'data' => ['foo' => 'bar']
]
```

This array was then passed in as separate items into the `->map` which ended up causing issues. By adding an `Arr::wrap`, single items, like the `Model` will now be wrapped in an array before going into the Illuminate Collection.

Fixes duncanmcclean/simple-commerce#1016