### PR TITLE
[6.x] Fix permissions grouped under "Miscellaneous"

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -114,23 +114,25 @@ class ServiceProvider extends AddonServiceProvider
 
     protected function registerPermissions(): self
     {
-        foreach (Runway::allResources() as $resource) {
-            Permission::register("view {$resource->handle()}", function ($permission) use ($resource) {
-                $permission
-                    ->label($this->permissionLabel('view', $resource))
-                    ->children([
-                        Permission::make("edit {$resource->handle()}")
-                            ->label($this->permissionLabel('edit', $resource))
-                            ->children([
-                                Permission::make("create {$resource->handle()}")
-                                    ->label($this->permissionLabel('create', $resource)),
+        Permission::group('runway', 'Runway', function () {
+            foreach (Runway::allResources() as $resource) {
+                Permission::register("view {$resource->handle()}", function ($permission) use ($resource) {
+                    $permission
+                        ->label($this->permissionLabel('view', $resource))
+                        ->children([
+                            Permission::make("edit {$resource->handle()}")
+                                ->label($this->permissionLabel('edit', $resource))
+                                ->children([
+                                    Permission::make("create {$resource->handle()}")
+                                        ->label($this->permissionLabel('create', $resource)),
 
-                                Permission::make("delete {$resource->handle()}")
-                                    ->label($this->permissionLabel('delete', $resource)),
-                            ]),
-                    ]);
-            })->group('Runway');
-        }
+                                    Permission::make("delete {$resource->handle()}")
+                                        ->label($this->permissionLabel('delete', $resource)),
+                                ]),
+                        ]);
+                });
+            }
+        });
 
         return $this;
     }


### PR DESCRIPTION
Prior to this PR, the permission set for Runway resources (eg, as seen when creating a new `role`) was grouped in with **Miscellaneous**, resulting in a duplicate header and no Runway section. This change updates the `registerPermissions` method in Runway's service provider, by swapping the trailing `->group` call for a `::group` closure/wrapper, as outlined in **[Statamic's docs](https://statamic.dev/extending/permissions#groups)**.

### Before:
![image](https://github.com/statamic-rad-pack/runway/assets/13950848/e4f99d46-d774-450b-9c3f-7ffd63dd7622)

### After:
![image](https://github.com/statamic-rad-pack/runway/assets/13950848/4def1c40-b074-4749-b480-84bf647dd958)
