### PR TITLE
[6.x] Fix issue when wrapping values for augmentation

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -213,7 +213,7 @@ class BaseFieldtype extends Relationship
 
     protected function getAugmentableModels(Resource $resource, $values): Collection
     {
-        return collect(Arr::wrap($values))
+        return collect($values instanceof Collection ? $values : Arr::wrap($values))
             ->map(function ($model) use ($resource) {
                 if (! $model instanceof Model) {
                     $eagerLoadingRelationships = collect($this->config('with') ?? [])->join(',');


### PR DESCRIPTION
This pull request follows on from #440, fixing an issue where `Collection` instances would be wrapped into an array with a single item.

This doesn't match up to an existing issue but something I just noticed while testing something else.