### PR TITLE
[6.x] Prevent all listable columns from being processed, even when they're not needed

### DIFF
--- a/src/Http/Controllers/CP/ResourceListingController.php
+++ b/src/Http/Controllers/CP/ResourceListingController.php
@@ -42,7 +42,6 @@ class ResourceListingController extends CpController
         return (new ResourceCollection($results))
             ->setResourceHandle($resource->handle())
             ->setColumnPreferenceKey("runway.{$resource->handle()}.columns")
-            ->setColumns($this->buildColumns($resource, $blueprint))
             ->additional([
                 'meta' => [
                     'activeFilterBadges' => $activeFilterBadges,

--- a/src/Http/Resources/ResourceCollection.php
+++ b/src/Http/Resources/ResourceCollection.php
@@ -60,12 +60,13 @@ class ResourceCollection extends LaravelResourceCollection
         $handle = $this->resourceHandle;
 
         return [
-            'data' => $this->collection->map(function ($model) use ($columns, $handle) {
+            'data' => $this->collection->map(function ($model) use ($handle) {
                 $row = $model->toArray();
 
                 foreach ($row as $key => $value) {
                     if (! $this->requestedColumns()->contains('field', $key)) {
                         unset($row[$key]);
+
                         continue;
                     }
 


### PR DESCRIPTION
This pull request fixes an issue where all listable columns were being processed in the `ResourceCollection@toArray` method.

Even though we did have a check to ensure columns existed in the `$columns` array before actually processing them, it turns out the `$columns` array actually included columns we don't need/want.

Instead, we're now checking against the `requestedColumns()` method (provided by the `HasRequestedColumns` trait) which will give us the columns provided in the request, then fallback to the columns from the blueprint.