### PR TITLE
Update form requests for new route/model binding

### DIFF
--- a/src/Http/Requests/CP/EditRequest.php
+++ b/src/Http/Requests/CP/EditRequest.php
@@ -11,7 +11,7 @@ class EditRequest extends FormRequest
     {
         $resource = $this->route('resource');
 
-        $model = $resource->model()::find($this->record);
+        $model = $resource->model()::find($this->model);
 
         return User::current()->can('edit', [$resource, $model]);
     }

--- a/src/Http/Requests/CP/UpdateRequest.php
+++ b/src/Http/Requests/CP/UpdateRequest.php
@@ -15,7 +15,7 @@ class UpdateRequest extends FormRequest
             return false;
         }
 
-        $model = $resource->model()->find($this->record);
+        $model = $resource->model()->find($this->model);
 
         return User::current()->can('edit', [$resource, $model]);
     }


### PR DESCRIPTION
V6 changed the route/model binding for the`statamic.cp.runway.update` and `statamic.cp.runway.edit` routes from `record` to model`.

`EditRequest` and `UpdateRequest` were not updated to match.

I didn't see any tests for the policies, but I can add if you let me know how you'd like those done.