### PR TITLE
[6.x] Accept --no-interaction option for the runway:rebuild-uris command and disable user prompt

### DIFF
--- a/src/Console/Commands/RebuildUriCache.php
+++ b/src/Console/Commands/RebuildUriCache.php
@@ -45,12 +45,14 @@ class RebuildUriCache extends Command
      */
     public function handle()
     {
-        $confirm = $this->confirm(
-            'You are about to rebuild your entire URI cache. This may take part of your site down while running. Are you sure you want to continue?'
-        );
+        if (!$this->option('no-interaction')) {
+            $confirm = $this->confirm(
+                'You are about to rebuild your entire URI cache. This may take part of your site down while running. Are you sure you want to continue?'
+            );
 
-        if (! $confirm) {
-            return;
+            if (! $confirm) {
+                return;
+            }
         }
 
         RunwayUri::all()->each->delete();


### PR DESCRIPTION
Disables the confirm prompt in the runway:rebuild-uris command. Useful for scripting the command or programmatically executing command.