### PR TITLE
[6.x] GraphQL: add resolver for fields with `_id`

### DIFF
--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -46,6 +46,10 @@ class ResourceType extends Type
                 $model = $resource->model()->firstWhere($resource->primaryKey(), $model);
             }
 
+            if (isset($model->{$info->fieldName.'_id'})) {
+                return $model->resolveGqlValue($info->fieldName.'_id');
+            }
+
             return $model->resolveGqlValue($info->fieldName);
         };
     }


### PR DESCRIPTION
The docs for [Belongs To](http://runway.duncanmcclean.com/fieldtypes) mention that a reference to a Statamic Entry doesn't need to be in the format of `model_id`, this is not true as it won't resolve it at all with the `_id` suffix as it won't be appended when resolving it.

This change would attempt to resolve the property with the `_id` suffix, so it would be possible to have a column called `model_id`.