### PR TITLE
[6.x] Fix `runway:generate-blueprint` command generating fields with incorrect fieldtype

### DIFF
--- a/src/Console/Commands/GenerateBlueprint.php
+++ b/src/Console/Commands/GenerateBlueprint.php
@@ -62,10 +62,10 @@ class GenerateBlueprint extends Command
             'normal' => 'date',
         ],
         \Doctrine\DBAL\Types\DecimalType::class => [
-            'normal' => 'floatval',
+            'normal' => 'float',
         ],
         \Doctrine\DBAL\Types\FloatType::class => [
-            'normal' => 'floatval',
+            'normal' => 'float',
         ],
         \Doctrine\DBAL\Types\GuidType::class => [],
         \Doctrine\DBAL\Types\IntegerType::class => [


### PR DESCRIPTION
This pull request fixes an issue with the `runway:generate-blueprint` command where decimal and float columns were being generated as `floatval` fields, when they should have been `float` fields.

Fixes #459.