### PR TITLE
[6.x] Catch `QueryException` when registering Runway's blueprint namespaces

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -173,7 +173,7 @@ class ServiceProvider extends AddonServiceProvider
             // yet to be migrated (for example: during a fresh install). We'll catch the exception here and
             // ignore it to prevent any errors during the `composer dump-autoload` command.
 
-            Log::warning("Runway attempted to register its blueprint namespace. However, it seems the `blueprints` table has yet to be migrated.");
+            Log::warning('Runway attempted to register its blueprint namespace. However, it seems the `blueprints` table has yet to be migrated.');
         }
 
         return $this;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -82,7 +82,6 @@ class ServiceProvider extends AddonServiceProvider
         ], 'runway-config');
 
         Statamic::booted(function () {
-
             Runway::discoverResources();
 
             $this
@@ -163,6 +162,10 @@ class ServiceProvider extends AddonServiceProvider
 
     protected function registerBlueprints(): self
     {
+        if (app()->runningInConsole()) {
+            return $this;
+        }
+
         Blueprint::addNamespace('runway', base_path('resources/blueprints/runway'));
 
         Runway::allResources()->each(fn (Resource $resource) => $resource->blueprint());

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -162,7 +162,7 @@ class ServiceProvider extends AddonServiceProvider
 
     protected function registerBlueprints(): self
     {
-        if (app()->runningInConsole()) {
+        if (app()->runningInConsole() && ! app()->runningUnitTests()) {
             return $this;
         }
 


### PR DESCRIPTION
This pull request aims to fix an issue where you'd experience a `QueryException` when running `composer dump-autoload`, due to the `blueprints` table having not been migrated yet.

This error is reproducible when installing the [Eloquent Driver](https://github.com/statamic/eloquent-driver) or setting up a fresh project which uses the Eloquent Driver.

The `blueprints` table didn't exist so when Runway tried to register its blueprint namespace, it failed. 

This PR attempts to fix the issue by catching the `QueryException` when registering the blueprint namespace to avoid the error showing up on fresh installs / deployments.

Fixes #465