### PR TITLE
[7.x] Drop `doctrine/dbal` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
     },
     "require": {
         "php": "^8.1",
-        "doctrine/dbal": "^3.7",
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "statamic/cms": "^4.44"
     },

--- a/src/Console/Commands/GenerateBlueprint.php
+++ b/src/Console/Commands/GenerateBlueprint.php
@@ -31,80 +31,24 @@ class GenerateBlueprint extends Command
      * The matching table for column types -> fieldtypes.
      */
     protected array $matching = [
-        \Doctrine\DBAL\Types\ArrayType::class => [
-            'type' => 'array',
-        ],
-        \Doctrine\DBAL\Types\AsciiType::class => [],
-        \Doctrine\DBAL\Types\BigIntType::class => [
-            'normal' => 'integer',
-        ],
-        \Doctrine\DBAL\Types\BinaryType::class => [],
-        \Doctrine\DBAL\Types\BlobType::class => [],
-        \Doctrine\DBAL\Types\BooleanType::class => [
-            'normal' => 'toggle',
-        ],
-        \Doctrine\DBAL\Types\DateImmutableType::class => [
-            'normal' => 'date',
-        ],
-        \Doctrine\DBAL\Types\DateTimeImmutableType::class => [
-            'normal' => 'date',
-        ],
-        \Doctrine\DBAL\Types\DateTimeType::class => [
-            'normal' => 'date',
-        ],
-        \Doctrine\DBAL\Types\DateTimeTzImmutableType::class => [
-            'normal' => 'date',
-        ],
-        \Doctrine\DBAL\Types\DateTimeTzType::class => [
-            'normal' => 'date',
-        ],
-        \Doctrine\DBAL\Types\DateType::class => [
-            'normal' => 'date',
-        ],
-        \Doctrine\DBAL\Types\DecimalType::class => [
-            'normal' => 'float',
-        ],
-        \Doctrine\DBAL\Types\FloatType::class => [
-            'normal' => 'float',
-        ],
-        \Doctrine\DBAL\Types\GuidType::class => [],
-        \Doctrine\DBAL\Types\IntegerType::class => [
-            'normal' => 'integer',
-        ],
-        \Doctrine\DBAL\Types\JsonType::class => [
-            'normal' => 'array',
-        ],
-        \Doctrine\DBAL\Types\ObjectType::class => [],
-        \Doctrine\DBAL\Types\PhpDateTimeMappingType::class => [
-            'normal' => 'date',
-        ],
-        \Doctrine\DBAL\Types\PhpIntegerMappingType::class => [
-            'normal' => 'integer',
-        ],
-        \Doctrine\DBAL\Types\SimpleArrayType::class => [
-            'normal' => 'array',
-        ],
-        \Doctrine\DBAL\Types\SmallIntType::class => [
-            'normal' => 'integer',
-        ],
-        \Doctrine\DBAL\Types\StringType::class => [
-            'normal' => 'text',
-        ],
-        \Doctrine\DBAL\Types\TextType::class => [
-            'normal' => 'textarea',
-        ],
-        \Doctrine\DBAL\Types\TimeImmutableType::class => [
-            'normal' => 'date',
-        ],
-        \Doctrine\DBAL\Types\TimeType::class => [
-            'normal' => 'date',
-        ],
-        \Doctrine\DBAL\Types\VarDateTimeImmutableType::class => [
-            'normal' => 'date',
-        ],
-        \Doctrine\DBAL\Types\VarDateTimeType::class => [
-            'normal' => 'date',
-        ],
+        'array' => ['type' => 'array'],
+        'bigint' => ['normal' => 'integer'],
+        'boolean' => ['normal' => 'toggle'],
+        'date_immutable' => ['normal' => 'date'],
+        'datetime_immutable' => ['normal' => 'date'],
+        'datetime' => ['normal' => 'date'],
+        'datetimetz_immutable' => ['normal' => 'date'],
+        'datetimetz' => ['normal' => 'date'],
+        'decimal' => ['normal' => 'float'],
+        'float' => ['normal' => 'float'],
+        'integer' => ['normal' => 'integer'],
+        'json' => ['normal' => 'array'],
+        'simple_array' => ['normal' => 'array'],
+        'smallint' => ['normal' => 'integer'],
+        'string' => ['normal' => 'text'],
+        'text' => ['normal' => 'textarea'],
+        'time_immutable' => ['normal' => 'date'],
+        'time' => ['normal' => 'date'],
     ];
 
     /**
@@ -150,15 +94,15 @@ class GenerateBlueprint extends Command
     {
         $errorMessages = [];
 
-        $columns = Schema::getConnection()->getDoctrineSchemaManager()->listTableColumns($resource->databaseTable());
+        $columns = Schema::getColumns($resource->databaseTable());
 
         $fields = collect($columns)
-            ->reject(fn (\Doctrine\DBAL\Schema\Column $column) => $column->getName() === 'id')
-            ->map(fn (\Doctrine\DBAL\Schema\Column $column) => [
-                'name' => $column->getName(),
+            ->reject(fn (array $column) => $column['name'] === 'id')
+            ->map(fn (array $column) => [
+                'name' => $column['name'],
                 'type' => $this->getMatchingFieldtype($column),
-                'nullable' => ! $column->getNotnull(),
-                'default' => $column->getDefault(),
+                'nullable' => $column['nullable'],
+                'default' => $column['default'],
                 'original_column' => $column,
             ])
             ->each(function ($field) use (&$errorMessages) {
@@ -184,15 +128,15 @@ class GenerateBlueprint extends Command
         }
     }
 
-    protected function getMatchingFieldtype(\Doctrine\DBAL\Schema\Column $column): ?string
+    protected function getMatchingFieldtype(array $column): ?string
     {
-        $match = $this->matching[$column->getType()::class] ?? null;
+        $match = $this->matching[$column['type_name']] ?? null;
 
         if (! $match) {
             return null;
         }
 
-        if ($match['normal'] === 'text' && $column->getName() === 'slug') {
+        if ($match['normal'] === 'text' && $column['name'] === 'slug') {
             return 'slug';
         }
 

--- a/tests/Console/Commands/GenerateBlueprintTest.php
+++ b/tests/Console/Commands/GenerateBlueprintTest.php
@@ -27,45 +27,65 @@ class GenerateBlueprintTest extends TestCase
     {
         Schema::shouldReceive('dropIfExists')->times(3);
 
-        Schema::shouldReceive('getConnection')
-            ->andReturnSelf()
-            ->shouldReceive('getDoctrineSchemaManager')
-            ->andReturnSelf()
-            ->shouldReceive('listTableColumns')
+        Schema::shouldReceive('getColumns')
             ->with('posts')
             ->andReturn([
-                new \Doctrine\DBAL\Schema\Column(
-                    'id',
-                    new \Doctrine\DBAL\Types\IntegerType(),
-                ),
-                new \Doctrine\DBAL\Schema\Column(
-                    'title',
-                    new \Doctrine\DBAL\Types\StringType(),
-                ),
-                (new \Doctrine\DBAL\Schema\Column(
-                    'description',
-                    new \Doctrine\DBAL\Types\TextType(),
-                ))->setNotnull(true),
-                (new \Doctrine\DBAL\Schema\Column(
-                    'price',
-                    new \Doctrine\DBAL\Types\IntegerType(),
-                ))->setDefault(4242),
-                (new \Doctrine\DBAL\Schema\Column(
-                    'metadata',
-                    new \Doctrine\DBAL\Types\JsonType(),
-                ))->setNotnull(true),
-                new \Doctrine\DBAL\Schema\Column(
-                    'date',
-                    new \Doctrine\DBAL\Types\DateType(),
-                ),
-                new \Doctrine\DBAL\Schema\Column(
-                    'created_at',
-                    new \Doctrine\DBAL\Types\DateTimeType(),
-                ),
-                new \Doctrine\DBAL\Schema\Column(
-                    'updated_at',
-                    new \Doctrine\DBAL\Types\DateTimeType(),
-                ),
+                [
+                    'name' => 'id',
+                    'type_name' => 'integer',
+                    'type' => 'integer',
+                    'nullable' => false,
+                    'default' => null,
+                ],
+                [
+                    'name' => 'title',
+                    'type_name' => 'string',
+                    'type' => 'string',
+                    'nullable' => true,
+                    'default' => null,
+                ],
+                [
+                    'name' => 'description',
+                    'type_name' => 'text',
+                    'type' => 'text',
+                    'nullable' => false,
+                    'default' => null,
+                ],
+                [
+                    'name' => 'price',
+                    'type_name' => 'integer',
+                    'type' => 'integer',
+                    'nullable' => false,
+                    'default' => 4242,
+                ],
+                [
+                    'name' => 'metadata',
+                    'type_name' => 'json',
+                    'type' => 'json',
+                    'nullable' => false,
+                    'default' => null,
+                ],
+                [
+                    'name' => 'date',
+                    'type_name' => 'date',
+                    'type' => 'date',
+                    'nullable' => true,
+                    'default' => null,
+                ],
+                [
+                    'name' => 'created_at',
+                    'type_name' => 'datetime',
+                    'type' => 'datetime',
+                    'nullable' => true,
+                    'default' => null,
+                ],
+                [
+                    'name' => 'updated_at',
+                    'type_name' => 'datetime',
+                    'type' => 'datetime',
+                    'nullable' => true,
+                    'default' => null,
+                ],
             ])
             ->once();
 
@@ -110,21 +130,23 @@ class GenerateBlueprintTest extends TestCase
     {
         Schema::shouldReceive('dropIfExists')->times(3);
 
-        Schema::shouldReceive('getConnection')
-            ->andReturnSelf()
-            ->shouldReceive('getDoctrineSchemaManager')
-            ->andReturnSelf()
-            ->shouldReceive('listTableColumns')
+        Schema::shouldReceive('getColumns')
             ->with('posts')
             ->andReturn([
-                new \Doctrine\DBAL\Schema\Column(
-                    'title',
-                    new \Doctrine\DBAL\Types\StringType(),
-                ),
-                (new \Doctrine\DBAL\Schema\Column(
-                    'blob',
-                    new \Doctrine\DBAL\Types\BlobType(),
-                )),
+                [
+                    'name' => 'title',
+                    'type_name' => 'string',
+                    'type' => 'string',
+                    'nullable' => true,
+                    'default' => null,
+                ],
+                [
+                    'name' => 'blob',
+                    'type_name' => 'blob',
+                    'type' => 'blob',
+                    'nullable' => true,
+                    'default' => null,
+                ],
             ])
             ->once();
 


### PR DESCRIPTION
This pull request drops our `doctrine/dbal` dependency, in favour of provided Laravel methods. 