### PR TITLE
[6.x] Fix N+1 queries in ResourceActionController

### DIFF
--- a/src/Http/Controllers/CP/ResourceActionController.php
+++ b/src/Http/Controllers/CP/ResourceActionController.php
@@ -26,6 +26,6 @@ class ResourceActionController extends ActionController
 
     protected function getSelectedItems($items, $context)
     {
-        return $items->map(fn ($item) => $this->resource->find($item));
+        return $this->resource->findMany($items);
     }
 }


### PR DESCRIPTION
Closes #469. After this change, models are essentially eager-loaded, using the `findMany` method inside `getSelectedItems`. See #469 for a before, and here's an after (see query counter in the debugbar):

![n-plus-1-after](https://github.com/statamic-rad-pack/runway/assets/13950848/2a2d6051-2757-4475-a09e-d8ce2055dba1)

This also has (what I would consider) an added benefit, by returning an _eloquent_ collection, instead of a generic collection. Allows you to do some handy things within the `Action` class itself, like `$items->load('anotherRelation')`. Wanted to mention this in case it impacts anything downstream that I'm unaware of, but should just be a net-positive since the eloquent collection class extends the base collection class. 👍

Let me know if we need to tweak anything, here!