### PR TITLE
[6.x] Fix runway resources getting added to the wrong section when using other languages than English

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -152,7 +152,7 @@ class ServiceProvider extends AddonServiceProvider
                 ->reject(fn ($resource) => $resource->hidden())
                 ->each(function (Resource $resource) use (&$nav) {
                     $nav->create($resource->name())
-                        ->section(__('Content'))
+                        ->section('Content')
                         ->icon($resource->cpIcon())
                         ->route('runway.index', ['resource' => $resource->handle()])
                         ->can('view', $resource);


### PR DESCRIPTION
This fixes #473 