### PR TITLE
[6.x] Throw exception when blueprint is empty

### DIFF
--- a/src/Exceptions/EmptyBlueprintException.php
+++ b/src/Exceptions/EmptyBlueprintException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace StatamicRadPack\Runway\Exceptions;
+
+class EmptyBlueprintException extends \Exception
+{
+    public function __construct(protected string $resourceHandle)
+    {
+        parent::__construct("The blueprint for the {$this->resourceHandle} resource is empty. Please add fields to the blueprint.");
+    }
+}

--- a/src/Http/Controllers/CP/Traits/HasListingColumns.php
+++ b/src/Http/Controllers/CP/Traits/HasListingColumns.php
@@ -5,12 +5,17 @@ namespace StatamicRadPack\Runway\Http\Controllers\CP\Traits;
 use Illuminate\Support\Arr;
 use Statamic\Facades\User;
 use Statamic\Fields\Field;
+use StatamicRadPack\Runway\Exceptions\EmptyBlueprintException;
 use StatamicRadPack\Runway\Resource;
 
 trait HasListingColumns
 {
     protected function getPrimaryColumn(Resource $resource): string
     {
+        if ($resource->blueprint()->fields()->all()->isEmpty()) {
+            throw new EmptyBlueprintException($resource->handle());
+        }
+
         if (Arr::has(User::current()->preferences(), "runway.{$resource->handle()}.columns")) {
             return collect($resource->blueprint()->fields()->all())
                 ->filter(function (Field $field) use ($resource) {


### PR DESCRIPTION
This pull request improves the error handling around visiting the resource listing page in the CP for a resource with an empty blueprint.

Previously, when you visited a resource listing page with an empty blueprint, you'd get an error message.