### PR TITLE
[6.x] Add missing close button on Runway's inline publish form

### DIFF
--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -238,8 +238,8 @@ export default {
                         })
                     } else {
                         this.quickSave = false
-
                         this.$toast.success(__('Saved'))
+                        this.$nextTick(() => this.$emit('saved', response));
                     }
                 })
                 .catch((error) => this.handleAxiosError(error))

--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -36,6 +36,8 @@
                     </button>
                 </save-button-options>
             </div>
+
+            <slot name="action-buttons-right" />
         </div>
 
         <publish-container

--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -6,7 +6,7 @@
             :title="breadcrumbs[0].text"
         />
 
-        <div class="flex items-center mb-3">
+        <div class="flex items-center mb-6">
             <h1 class="flex-1">
                 <div class="flex items-center">
                     <span v-html="title" />


### PR DESCRIPTION
This pull request adds the missing close button to the top-right of Runway's inline publish form:

![CleanShot 2024-05-03 at 15 47 11](https://github.com/statamic-rad-pack/runway/assets/19637309/c68ae026-8ccf-4ec0-8c18-4f56a6110570)

This PR also tweaks some styling and emits a `saved` event after the model has been successfully saved.

Fixes #478.