### PR TITLE
[6.x] Pass `reference` through to publish containers

### DIFF
--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -43,6 +43,7 @@
         <publish-container
             ref="container"
             :name="publishContainer"
+            :reference="initialReference"
             :blueprint="blueprint"
             :values="values"
             :meta="meta"
@@ -117,6 +118,7 @@ export default {
 
     props: {
         breadcrumbs: Array,
+        initialReference: String,
         initialActions: Object,
         initialBlueprint: Object,
         initialValues: Object,

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -7,6 +7,7 @@
 @section('content')
     <runway-publish-form
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
+        initial-reference="{{ $currentModel['reference'] }}"
         :initial-actions="{{ json_encode($actions) }}"
         :initial-blueprint='@json($blueprint)'
         :initial-meta='@json($meta)'

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -286,6 +286,7 @@ class BaseFieldtype extends Relationship
 
         return [
             'id' => $model->getKey(),
+            'reference' => $model->reference(),
             'title' => $this->makeTitle($model, $resource),
             'edit_url' => $editUrl,
         ];

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -149,6 +149,7 @@ class ResourceController extends CpController
             'resourceHasRoutes' => $resource->hasRouting(),
             'currentModel' => [
                 'id' => $model->getKey(),
+                'reference' => $model->reference(),
                 'title' => $model->{$resource->titleField()},
                 'edit_url' => $request->url(),
             ],

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -37,6 +37,11 @@ trait HasRunwayResource
         return Runway::findResourceByModel($this);
     }
 
+    public function reference(): string
+    {
+        return "runway::{$this->runwayResource()->handle()}::{$this->getKey()}";
+    }
+
     public function scopeRunwaySearch(Builder $query, string $searchQuery)
     {
         $this->runwayResource()->blueprint()->fields()->all()


### PR DESCRIPTION
This pull request gives models the concept of "references", which are used by entries/terms/assets/etc to be a unique identifier of _things_ in Statamic.

We're then passing the `reference` down to the publish container, so it's available to be checked against in my recursive editing fix in core.

Related: statamic/cms#10012