### PR TITLE
[7.x] Improve exception handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     },
     "require": {
         "php": "^8.2",
+        "ajthinking/archetype": "^1.0.3 || ^2.0",
         "laravel/framework": "^10.25.0 || ^11.0",
         "laravel/prompts": "^0.1.17",
         "pixelfear/composer-dist-plugin": "^0.1.5",

--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,10 @@
     },
     "require": {
         "php": "^8.2",
-        "laravel/prompts": "^0.1.17",
         "laravel/framework": "^10.25.0 || ^11.0",
+        "laravel/prompts": "^0.1.17",
         "pixelfear/composer-dist-plugin": "^0.1.5",
+        "spatie/ignition": "^1.14",
         "statamic/cms": "^5.0"
     },
     "require-dev": {

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -8,7 +8,7 @@
 
         @can('configure fields')
             <dropdown-list class="mr-2">
-                <dropdown-item :text="__('Edit Blueprints')" redirect="{{ cp_route('blueprints.edit', ['namespace' => 'runway', 'handle' => $resource->handle()]) }}"></dropdown-item>
+                <dropdown-item :text="__('Edit Blueprint')" redirect="{{ cp_route('blueprints.edit', ['namespace' => 'runway', 'handle' => $resource->handle()]) }}"></dropdown-item>
             </dropdown-list>
         @endcan
 

--- a/src/Exceptions/EmptyBlueprintException.php
+++ b/src/Exceptions/EmptyBlueprintException.php
@@ -2,10 +2,24 @@
 
 namespace StatamicRadPack\Runway\Exceptions;
 
-class EmptyBlueprintException extends \Exception
+use Spatie\Ignition\Contracts\ProvidesSolution;
+use Spatie\Ignition\Contracts\Solution;
+use Spatie\Ignition\Contracts\BaseSolution;
+
+class EmptyBlueprintException extends \Exception implements ProvidesSolution
 {
     public function __construct(protected string $resourceHandle)
     {
-        parent::__construct("The blueprint for the {$this->resourceHandle} resource is empty. Please add fields to the blueprint.");
+        parent::__construct("There are no fields defined in the {$this->resourceHandle} blueprint.");
+    }
+
+    public function getSolution(): Solution
+    {
+        return BaseSolution::create("Add fields to the {$this->resourceHandle} blueprint")
+            ->setSolutionDescription('Before you can view this resource in the Control Panel, you need to define fields in its blueprint.')
+            ->setDocumentationLinks([
+                'Edit blueprint' => cp_route('blueprints.edit', ['namespace' => 'runway', 'handle' => $this->resourceHandle]),
+                'Review the docs' => 'https://runway.duncanmcclean.com/blueprints',
+            ]);
     }
 }

--- a/src/Exceptions/TraitMissingException.php
+++ b/src/Exceptions/TraitMissingException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace StatamicRadPack\Runway\Exceptions;
+
+use Spatie\Ignition\Contracts\ProvidesSolution;
+use Spatie\Ignition\Contracts\Solution;
+use StatamicRadPack\Runway\Ignition\Solutions\AddTraitToModel;
+
+class TraitMissingException extends \Exception implements ProvidesSolution
+{
+    public function __construct(protected string $model)
+    {
+        parent::__construct("The HasRunwayResource trait is missing from the [{$model}] model");
+    }
+
+    public function getSolution(): Solution
+    {
+        return new AddTraitToModel($this->model);
+    }
+}

--- a/src/Ignition/Solutions/AddTraitToModel.php
+++ b/src/Ignition/Solutions/AddTraitToModel.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace StatamicRadPack\Runway\Ignition\Solutions;
+
+use Archetype\Facades\PHPFile;
+use Illuminate\Support\Str;
+use Spatie\Ignition\Contracts\RunnableSolution;
+use StatamicRadPack\Runway\Traits\HasRunwayResource;
+
+class AddTraitToModel implements RunnableSolution
+{
+    public function __construct(protected $model = null)
+    {
+    }
+
+    public function getSolutionTitle(): string
+    {
+        $model = Str::after($this->model, 'App\\Models\\');
+
+        return "Add HasRunwayResource trait to the {$model} model";
+    }
+
+    public function getSolutionDescription(): string
+    {
+        return 'You need to add the `HasRunwayResource` trait to your model in order to use it with Runway.';
+    }
+
+    public function getDocumentationLinks(): array
+    {
+        return [
+            'Learn more' => 'https://runway.duncanmcclean.com/resources#content-defining-resources',
+        ];
+    }
+
+    public function getSolutionActionDescription(): string
+    {
+        return 'Runway can attempt to add it for you.';
+    }
+
+    public function getRunButtonText(): string
+    {
+        return 'Add trait';
+    }
+
+    public function run(array $parameters = []): void
+    {
+        PHPFile::load($parameters['model'])
+            ->add()->use([HasRunwayResource::class])
+            ->add()->useTrait('HasRunwayResource')
+            ->save();
+    }
+
+    public function getRunParameters(): array
+    {
+        return [
+            'model' => $this->model,
+        ];
+    }
+}

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use StatamicRadPack\Runway\Exceptions\ResourceNotFound;
+use StatamicRadPack\Runway\Exceptions\TraitMissingException;
 
 class Runway
 {
@@ -20,7 +21,7 @@ class Runway
 
                 throw_if(
                     ! in_array(Traits\HasRunwayResource::class, class_uses_recursive($model)),
-                    new \Exception(__('The HasRunwayResource trait is missing from the [:model] model.', ['model' => $model]))
+                    new TraitMissingException($model),
                 );
 
                 $resource = new Resource(

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Statamic\API\Middleware\Cache;
 use Statamic\Facades\Blueprint;
@@ -85,7 +86,9 @@ class ServiceProvider extends AddonServiceProvider
         ], 'runway-config');
 
         Statamic::booted(function () {
-            Runway::discoverResources();
+            if ($this->shouldDiscoverResources()) {
+                Runway::discoverResources();
+            }
 
             $this
                 ->registerRouteBindings()
@@ -269,5 +272,14 @@ class ServiceProvider extends AddonServiceProvider
         }
 
         return $label;
+    }
+
+    protected function shouldDiscoverResources(): bool
+    {
+        if (Str::startsWith(request()->path(), '_ignition/')) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
This pull request makes some improvements to how Runway's exceptions are handled, including adding Ignition solutions.

## When `HasRunwayResource` trait is missing from Eloquent Model

When you add an Eloquent Model to the `runway.php` config file but forget to add the `HasRunwayResource` trait, you'll now be able to add straight from the exception page by clicking the "Add trait" button.

![CleanShot 2024-05-20 at 10 28 33](https://github.com/statamic-rad-pack/runway/assets/19637309/e3f2ce76-bd26-418c-ab94-27c3d4df1729)

## When resource blueprint is empty

When you try to view a resource's listing page **without** any fields in its blueprint, you'll see an exception prompting you to add some.

With these improvements, you're now able to click the "Edit blueprint" link to go directly to the blueprint builder to start adding fields.

![CleanShot 2024-05-20 at 10 30 57](https://github.com/statamic-rad-pack/runway/assets/19637309/2c88a488-1f89-4f81-a99a-d580a5ebf0ad)
