### PR TITLE
[7.x] Add ability to customize URIs table name

### DIFF
--- a/config/runway.php
+++ b/config/runway.php
@@ -19,6 +19,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Runway URIs Table
+    |--------------------------------------------------------------------------
+    |
+    | When using Runway's front-end routing functionality, Runway will store model
+    | URIs in a table to enable easy "URI -> model" lookups. If needed, you can
+    | customize the table name here.
+    |
+    */
+
+    'uris_table' => 'runway_uris',
+
+    /*
+    |--------------------------------------------------------------------------
     | Disable Migrations?
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/2021_05_04_162552_create_runway_uris_table.php
+++ b/database/migrations/2021_05_04_162552_create_runway_uris_table.php
@@ -13,7 +13,7 @@ class CreateRunwayUrisTable extends Migration
      */
     public function up()
     {
-        Schema::create('runway_uris', function (Blueprint $table) {
+        Schema::create(config('runway.uris_table', 'runway_uris'), function (Blueprint $table) {
             $table->id();
             $table->string('uri');
             $table->string('model_type');
@@ -29,6 +29,6 @@ class CreateRunwayUrisTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('runway_uris');
+        Schema::dropIfExists(config('runway.uris_table', 'runway_uris'));
     }
 }

--- a/docs/frontend-routing.md
+++ b/docs/frontend-routing.md
@@ -101,3 +101,22 @@ class Product extends Model
 	}
 }
 ```
+
+### Customizing the table name
+
+By default, Runway will use the `runway_uris` table to store the "URI Cache". If you wish to change the name of the table, you may do so in the `runway.php` configuration file:
+
+```php 
+/*
+|--------------------------------------------------------------------------
+| Runway URIs Table
+|--------------------------------------------------------------------------
+|
+| When using Runway's front-end routing functionality, Runway will store model
+| URIs in a table to enable easy "URI -> model" lookups. If needed, you can
+| customize the table name here.
+|
+*/
+
+'uris_table' => 'runway_uris',
+```

--- a/src/Routing/RunwayUri.php
+++ b/src/Routing/RunwayUri.php
@@ -13,4 +13,9 @@ class RunwayUri extends Model
     {
         return $this->morphTo();
     }
+
+    public function getTable()
+    {
+        return config('runway.uris_table', 'runway_uris');
+    }
 }


### PR DESCRIPTION
This pull request adds a new `uris_table` configuration option, allowing developers to customize the name of the table used for the "URI Cache".

Related: #490