### PR TITLE
[7.x] Publish States

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -183,6 +183,22 @@ However, if you wish, you can override the relationships that get eager loaded b
 ],
 ```
 
+### Published States
+
+If you're storing content that you'd like to be able to publish and unpublish, you can add the `published` config option which will allow you to manage publish states for a Runway model:
+
+```php
+'resources' => [
+	\App\Models\Order::class => [
+	    'name' => 'Orders',
+		'published' => true, // Assumes the model has a `published` boolean column.
+		'published' => 'active', // Otherwise, you can specify the column name.
+	],
+],
+```
+
+This will add a "Published" toggle to the resource's publish form, status indicators in the Control Panel, and filter out unpublished models during augmentation. 
+
 ## Actions
 
 In much the same way with entries, you can create custom Actions which will be usable in the listing tables provided by Runway.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -183,9 +183,9 @@ However, if you wish, you can override the relationships that get eager loaded b
 ],
 ```
 
-### Published States
+### Publish States
 
-If you're storing content that you'd like to be able to publish and unpublish, you can add the `published` config option which will allow you to manage publish states for a Runway model:
+If you're storing content you'd like to be able to store without publishing right away, you can use the `published` config option to add a "Published" toggle to your Runway model:
 
 ```php
 'resources' => [
@@ -197,7 +197,7 @@ If you're storing content that you'd like to be able to publish and unpublish, y
 ],
 ```
 
-This will add a "Published" toggle to the resource's publish form, status indicators in the Control Panel, and filter out unpublished models during augmentation. 
+In addition to adding the "Published" toggle, you'll see status indicators in the Control Panel and unpublished models will be filtered out during augmentation, in a very similar way to how Statamic deals with unpublished content.
 
 ## Actions
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -29,7 +29,7 @@ Next, you'll need to enable the resources you want to make available. To do this
     'collections' => true,
     // ...
     'runway' => [
-        'product' => true,
+        'products' => true,
     ],
 ],
 ```
@@ -47,7 +47,7 @@ To enable filtering for your resources, you'll need to opt in by defining a list
 
 ```php
 'runway' => [
-    'product' => [
+    'products' => [
         'allowed_filters' => ['name', 'slug'],
     ],
 ],

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -129,6 +129,19 @@ As [with the collection tag](https://statamic.dev/tags/collection#scope), you ma
 {{ /runway:post }}
 ```
 
+## Publish State
+
+By default, when you're using Runway's [Publish States](/resources#publish-states) feature, only published models are included. Models can be queried against `published` or `draft` status with conditions on `status` like this:
+
+```antlers
+{{ runway:post status="published" }}
+    {{ posts }}
+        <h2>{{ title }}</h2>
+        <p>{{ intro_text }}</p>
+    {{ /posts }}
+{{ /runway:post }}
+```
+
 ### Pagination
 
 If you want to paginate your results onto multiple pages, you can use the `paginate` parameter, along with [scoping](#scoping) and [limiting](#limiting).

--- a/resources/js/components/Listing/RunwayListing.vue
+++ b/resources/js/components/Listing/RunwayListing.vue
@@ -15,9 +15,7 @@
         >
             <div slot-scope="{ hasSelections }">
                 <div class="card overflow-hidden p-0 relative">
-                    <div
-                        class="flex flex-wrap items-center justify-between px-2 pb-2 text-sm border-b dark:border-dark-900"
-                    >
+                    <div class="flex flex-wrap items-center justify-between px-2 pb-2 text-sm border-b dark:border-dark-900">
                         <data-list-filter-presets
                             ref="presets"
                             v-show="alwaysShowFilters || !showFilters"
@@ -101,13 +99,15 @@
                             :column-preferences-key="preferencesKey('columns')"
                             @sorted="sorted"
                         >
-                            <template
-                                :slot="primaryColumn"
-                                slot-scope="{ row, value }"
-                            >
-                                <a :href="row.edit_url" @click.stop>{{
-                                    value
-                                }}</a>
+                            <template :slot="primaryColumn" slot-scope="{ row: model, value }">
+                                <a class="title-index-field inline-flex items-center" :href="model.edit_url" @click.stop>
+                                    <span class="little-dot rtl:ml-2 ltr:mr-2" v-tooltip="getStatusLabel(model)" :class="getStatusClass(model)" v-if="hasPublishStates && ! columnShowing('status')" />
+                                    <span v-text="value" />
+                                </a>
+                            </template>
+
+                            <template v-if="hasPublishStates" slot="cell-status" slot-scope="{ row: model }">
+                                <div class="status-index-field select-none" v-tooltip="getStatusTooltip(model)" :class="`status-${model.status}`" v-text="getStatusLabel(model)" />
                             </template>
 
                             <template
@@ -196,6 +196,7 @@ export default {
         initialColumns: Array,
         actionUrl: String,
         initialPrimaryColumn: String,
+        hasPublishStates: Boolean,
     },
 
     data() {
@@ -211,6 +212,34 @@ export default {
     },
 
     methods: {
+        getStatusClass(model) {
+            if (model.published) {
+                return 'bg-green-600';
+            } else {
+                return 'bg-gray-400';
+            }
+        },
+
+        getStatusLabel(model) {
+            if (model.status === 'published') {
+                return __('Published');
+            } else if (model.status === 'draft') {
+                return __('Draft');
+            }
+        },
+
+        getStatusTooltip(model) {
+            if (model.status === 'published') {
+                return null; // Models don't have publish dates.
+            } else if (model.status === 'draft') {
+                return null; // The label is sufficient.
+            }
+        },
+
+        columnShowing(column) {
+            return this.visibleColumns.find(c => c.field === column);
+        },
+
         canViewRow(row) {
             return row.viewable && row.permalink
         },

--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -79,19 +79,15 @@
                     @blur="$refs.container.$emit('blur', $event)"
                 >
                     <template #actions="{ shouldShowSidebar }">
-                        <div v-if="shouldShowSidebar" class="card p-0" :class="{ 'mb-5': resourceHasRoutes && permalink }">
-                            <div
-                                v-if="resourceHasRoutes && permalink"
-                                :class="{ hi: !shouldShowSidebar }"
-                            >
-                                <div class="p-3 flex items-center space-x-2">
+                        <div class="card p-0 mb-5">
+                            <div v-if="resourceHasRoutes" :class="{ 'hi': resourceHasRoutes && permalink }">
+                                <div class="p-3 flex items-center space-x-2" v-if="showVisitUrlButton">
                                     <a
                                         class="flex items-center justify-center btn w-full"
-                                        v-if="permalink"
+                                        v-if="showVisitUrlButton"
                                         :href="permalink"
-                                        target="_blank"
-                                    >
-                                        <svg-icon name="light/external-link" class="w-4 h-4 mr-2 shrink-0" />
+                                        target="_blank">
+                                        <svg-icon name="light/external-link" class="w-4 h-4 rtl:ml-2 ltr:mr-2 shrink-0" />
                                         <span>{{ __('Visit URL') }}</span>
                                     </a>
                                 </div>
@@ -201,6 +197,10 @@ export default {
 
         shouldShowSidebar() {
             return this.enableSidebar
+        },
+
+        showVisitUrlButton() {
+            return !!this.permalink;
         },
 
         afterSaveOption() {

--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -103,7 +103,7 @@
                                     :class="{ 'border-t dark:border-dark-900': resourceHasRoutes && permalink }"
                                 >
                                     <label v-text="__('Published')" class="publish-field-label font-medium" />
-                                    <toggle-input :value="published" :read-only="!canManagePublishState" @input="setFieldValue('published', $event)" />
+                                    <toggle-input :value="published" :read-only="!canManagePublishState" @input="setFieldValue(publishedColumn, $event)" />
                                 </div>
                             </div>
                         </div>
@@ -167,6 +167,7 @@ export default {
         listingUrl: String,
         canEditBlueprint: Boolean,
         canManagePublishState: Boolean,
+        publishedColumn: String,
     },
 
     data() {
@@ -187,7 +188,7 @@ export default {
             // Whether it was published the last time it was saved.
             // Successful publish actions (if using revisions) or just saving (if not) will update this.
             // The current published value is inside the "values" object, and also accessible as a computed.
-            initialPublished: this.initialValues.published,
+            initialPublished: this.initialValues[this.publishedColumn],
         }
     },
 
@@ -207,7 +208,7 @@ export default {
         },
 
         published() {
-            return this.values.published;
+            return this.values[this.publishedColumn];
         },
 
         isUnpublishing() {
@@ -350,7 +351,7 @@ export default {
             if (response.data) {
                 this.title = response.data.title;
                 this.values = this.resetValuesFromResponse(response.data.values);
-                this.initialPublished = response.data.published;
+                this.initialPublished = response.data[this.publishedColumn];
                 this.itemActions = response.data.itemActions;
             }
         },

--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -96,6 +96,16 @@
                                     </a>
                                 </div>
                             </div>
+
+                            <div v-if="canManagePublishState">
+                                <div
+                                    class="flex items-center justify-between px-4 py-2"
+                                    :class="{ 'border-t dark:border-dark-900': resourceHasRoutes && permalink }"
+                                >
+                                    <label v-text="__('Published')" class="publish-field-label font-medium" />
+                                    <toggle-input :value="published" :read-only="!canManagePublishState" @input="setFieldValue('published', $event)" />
+                                </div>
+                            </div>
                         </div>
                     </template>
                 </publish-tabs>
@@ -156,6 +166,7 @@ export default {
         createAnotherUrl: String,
         listingUrl: String,
         canEditBlueprint: Boolean,
+        canManagePublishState: Boolean,
     },
 
     data() {
@@ -172,6 +183,11 @@ export default {
             containerWidth: null,
             saveKeyBinding: null,
             quickSave: false,
+
+            // Whether it was published the last time it was saved.
+            // Successful publish actions (if using revisions) or just saving (if not) will update this.
+            // The current published value is inside the "values" object, and also accessible as a computed.
+            initialPublished: this.initialValues.published,
         }
     },
 
@@ -188,6 +204,18 @@ export default {
 
         afterSaveOption() {
             return this.getPreference('after_save')
+        },
+
+        published() {
+            return this.values.published;
+        },
+
+        isUnpublishing() {
+            return this.initialPublished && ! this.published && ! this.isCreating;
+        },
+
+        isDraft() {
+            return ! this.published;
         },
     },
 
@@ -322,6 +350,7 @@ export default {
             if (response.data) {
                 this.title = response.data.title;
                 this.values = this.resetValuesFromResponse(response.data.values);
+                this.initialPublished = response.data.published;
                 this.itemActions = response.data.itemActions;
             }
         },

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -21,5 +21,6 @@
         create-another-url="{{ cp_route('runway.create', ['resource' => $resource->handle()]) }}"
         listing-url="{{ cp_route('runway.index', ['resource' => $resource->handle()]) }}"
         :can-manage-publish-state="{{ $str::bool($canManagePublishState) }}"
+        published-column="{{ $publishedColumn }}"
     ></runway-publish-form>
 @endsection

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -1,3 +1,4 @@
+@inject('str', 'Statamic\Support\Str')
 @extends('statamic::layout')
 @section('title', __('Create :resource', [
     'resource' => $resource->singular(),
@@ -19,5 +20,6 @@
         :resource='@json($resource->toArray())'
         create-another-url="{{ cp_route('runway.create', ['resource' => $resource->handle()]) }}"
         listing-url="{{ cp_route('runway.index', ['resource' => $resource->handle()]) }}"
+        :can-manage-publish-state="{{ $str::bool($canManagePublishState) }}"
     ></runway-publish-form>
 @endsection

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -1,3 +1,4 @@
+@inject('str', 'Statamic\Support\Str')
 @extends('statamic::layout')
 @section('title', __('Edit :resource', [
     'resource' => $resource->singular(),
@@ -23,6 +24,7 @@
         create-another-url="{{ cp_route('runway.create', ['resource' => $resource->handle()]) }}"
         listing-url="{{ cp_route('runway.index', ['resource' => $resource->handle()]) }}"
         :can-edit-blueprint="{{ Auth::user()->can('configure fields') ? 'true' : 'false' }}"
+        :can-manage-publish-state="{{ $str::bool($canManagePublishState) }}"
         :initial-item-actions="{{ json_encode($itemActions) }}"
         item-action-url="{{ cp_route('runway.actions.run', ['resource' => $resource->handle()]) }}"
     ></runway-publish-form>

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -27,6 +27,7 @@
         :can-manage-publish-state="{{ $str::bool($canManagePublishState) }}"
         :initial-item-actions="{{ json_encode($itemActions) }}"
         item-action-url="{{ cp_route('runway.actions.run', ['resource' => $resource->handle()]) }}"
+        published-column="{{ $publishedColumn }}"
     ></runway-publish-form>
 
     <script>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,3 +1,4 @@
+@inject('str', 'Statamic\Support\Str')
 @extends('statamic::layout')
 @section('title', $title)
 @section('wrapper_class', 'max-w-full')
@@ -32,5 +33,6 @@
         :initial-columns='@json($columns)'
         action-url="{{ $actionUrl }}"
         initial-primary-column="{{ $primaryColumn }}"
+        :has-publish-states="{{ $str::bool($hasPublishStates) }}"
     ></runway-listing>
 @endsection

--- a/src/Actions/Publish.php
+++ b/src/Actions/Publish.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace StatamicRadPack\Runway\Actions;
+
+use Illuminate\Database\Eloquent\Model;
+use Statamic\Actions\Action;
+use Statamic\Facades\User;
+
+class Publish extends Action
+{
+    public static function title()
+    {
+        return __('Publish');
+    }
+
+    public function visibleTo($item)
+    {
+        return $this->context['view'] === 'list'
+            && $item instanceof Model
+            && $item->runwayResource()->readOnly() !== true
+            && $item->runwayResource()->hasPublishStates()
+            && ! $item->{$item->runwayResource()->publishedColumn()};
+    }
+
+    public function visibleToBulk($items)
+    {
+        if ($items->filter(fn ($item) => $item->{$item->runwayResource()->publishedColumn()})->count() > 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function authorize($user, $item)
+    {
+        return $user->can('edit', [$item->runwayResource(), $item]);
+    }
+
+    public function confirmationText()
+    {
+        /** @translation */
+        return 'Are you sure you want to publish this model?|Are you sure you want to publish these :count models?';
+    }
+
+    public function buttonText()
+    {
+        /** @translation */
+        return 'Publish Model|Publish :count Models';
+    }
+
+    public function run($models, $values)
+    {
+        $models->each(function ($model) {
+            $model->{$model->runwayResource()->publishedColumn()} = true;
+            $model->save();
+        });
+    }
+}

--- a/src/Actions/Unpublish.php
+++ b/src/Actions/Unpublish.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace StatamicRadPack\Runway\Actions;
+
+use Illuminate\Database\Eloquent\Model;
+use Statamic\Actions\Action;
+use Statamic\Facades\User;
+
+class Unpublish extends Action
+{
+    public static function title()
+    {
+        return __('Unpublish');
+    }
+
+    public function visibleTo($item)
+    {
+        return $this->context['view'] === 'list'
+            && $item instanceof Model
+            && $item->runwayResource()->readOnly() !== true
+            && $item->runwayResource()->hasPublishStates()
+            && $item->{$item->runwayResource()->publishedColumn()};
+    }
+
+    public function visibleToBulk($items)
+    {
+        if ($items->reject(fn ($item) => $item->{$item->runwayResource()->publishedColumn()})->count() > 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function authorize($user, $item)
+    {
+        return $user->can('edit', [$item->runwayResource(), $item]);
+    }
+
+    public function confirmationText()
+    {
+        /** @translation */
+        return 'Are you sure you want to unpublish this model?|Are you sure you want to unpublish these :count models?';
+    }
+
+    public function buttonText()
+    {
+        /** @translation */
+        return 'Unpublish Model|Unpublish :count Models';
+    }
+
+    public function run($models, $values)
+    {
+        $models->each(function ($model) {
+            $model->{$model->runwayResource()->publishedColumn()} = false;
+            $model->save();
+        });
+    }
+}

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -121,6 +121,8 @@ class BaseFieldtype extends Relationship
                     ->merge([
                         'id' => $model->{$resource->primaryKey()},
                         'title' => $this->makeTitle($model, $resource),
+                        'status' => $resource->hasPublishStates() ? $model->publishedStatus() : null,
+                        'collection' => ['dated' => false],
                     ])
                     ->toArray();
             });
@@ -259,6 +261,15 @@ class BaseFieldtype extends Relationship
                     ->sortable($blueprintField->isSortable())
                     ->defaultOrder($index + 1);
             })
+            ->when($resource->hasPublishStates(), function ($collection) {
+                $collection->push(
+                    Column::make('status')
+                        ->listable(true)
+                        ->visible(true)
+                        ->defaultVisibility(true)
+                        ->sortable(false)
+                );
+            })
             ->toArray();
     }
 
@@ -288,6 +299,7 @@ class BaseFieldtype extends Relationship
         return [
             'id' => $model->getKey(),
             'reference' => $model->reference(),
+            'status' => $model->publishedStatus(),
             'title' => $this->makeTitle($model, $resource),
             'edit_url' => $editUrl,
         ];
@@ -319,5 +331,12 @@ class BaseFieldtype extends Relationship
     public function filter()
     {
         return new Models($this);
+    }
+
+    protected function statusIcons()
+    {
+        $resource = Runway::findResource($this->config('resource'));
+
+        return $resource->hasPublishStates();
     }
 }

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -37,6 +37,7 @@ class BaseFieldtype extends Relationship
         'permalink' => 'permalink',
         'resource' => 'resource',
         'breadcrumbs' => 'breadcrumbs',
+        'canManagePublishState' => 'canManagePublishState',
     ];
 
     protected function configFieldItems(): array

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -38,6 +38,7 @@ class BaseFieldtype extends Relationship
         'resource' => 'resource',
         'breadcrumbs' => 'breadcrumbs',
         'canManagePublishState' => 'canManagePublishState',
+        'publishedColumn' => 'publishedColumn',
     ];
 
     protected function configFieldItems(): array

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -39,6 +39,7 @@ class ResourceIndexQuery extends Query
     {
         $query = $this->resource->model()
             ->newQuery()
+            ->runwayStatus('published')
             ->with($this->resource->eagerLoadingRelationships());
 
         $this->filterQuery($query, $args['filter'] ?? []);

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -8,8 +8,6 @@ use Statamic\Facades\GraphQL;
 use Statamic\GraphQL\Queries\Concerns\FiltersQuery;
 use Statamic\GraphQL\Queries\Query;
 use Statamic\GraphQL\Types\JsonArgument;
-use Statamic\Support\Arr;
-use Statamic\Tags\Concerns\QueriesConditions;
 use StatamicRadPack\Runway\Resource;
 
 class ResourceIndexQuery extends Query

--- a/src/GraphQL/ResourceShowQuery.php
+++ b/src/GraphQL/ResourceShowQuery.php
@@ -29,6 +29,6 @@ class ResourceShowQuery extends Query
 
     public function resolve($root, $args)
     {
-        return $this->resource->model()->runwayStatus('published')->find($args[$this->resource->primaryKey()]);
+        return $this->resource->model()->whereStatus('published')->find($args[$this->resource->primaryKey()]);
     }
 }

--- a/src/GraphQL/ResourceShowQuery.php
+++ b/src/GraphQL/ResourceShowQuery.php
@@ -29,6 +29,6 @@ class ResourceShowQuery extends Query
 
     public function resolve($root, $args)
     {
-        return $this->resource->model()->find($args[$this->resource->primaryKey()]);
+        return $this->resource->model()->runwayStatus('published')->find($args[$this->resource->primaryKey()]);
     }
 }

--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -22,6 +22,10 @@ class ResourceType extends Type
     {
         return $this->resource->blueprint()->fields()->toGql()
             ->merge($this->nonBlueprintFields())
+            ->when($this->resource->hasPublishStates(), function ($collection) {
+                $collection->put('status', ['type' => GraphQL::nonNull(GraphQL::string())]);
+                $collection->put('published', ['type' => GraphQL::nonNull(GraphQL::boolean())]);
+            })
             ->mapWithKeys(fn ($value, $key) => [
                 Str::replace('_id', '', $key) => $value,
             ])
@@ -79,7 +83,6 @@ class ResourceType extends Type
                 return [$column['name'] => ['type' => $type]];
             })
             ->reject(fn ($item): bool => is_null($item['type']))
-            // ->dd()
             ->toArray();
     }
 }

--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -33,7 +33,7 @@ class ApiController extends StatamicApiController
             throw new NotFoundHttpException;
         }
 
-        $results = $this->filterSortAndPaginate($resource->model()->query());
+        $results = $this->filterSortAndPaginate($resource->model()->query()->runwayStatus('published'));
 
         $results = ApiResource::collection($results);
 
@@ -56,7 +56,7 @@ class ApiController extends StatamicApiController
             throw new NotFoundHttpException;
         }
 
-        if (! $model = $resource->model()->find($model)) {
+        if (! $model = $resource->model()->runwayStatus('published')->find($model)) {
             throw new NotFoundHttpException;
         }
 

--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -16,9 +16,8 @@ class ApiController extends StatamicApiController
     private $config;
 
     protected $resourceConfigKey = 'runway';
-
     protected $routeResourceKey = 'resourceHandle';
-
+    protected $filterPublished = true;
     protected $resourceHandle;
 
     public function index($resourceHandle)
@@ -33,7 +32,7 @@ class ApiController extends StatamicApiController
             throw new NotFoundHttpException;
         }
 
-        $results = $this->filterSortAndPaginate($resource->model()->query()->runwayStatus('published'));
+        $results = $this->filterSortAndPaginate($resource->model()->query());
 
         $results = ApiResource::collection($results);
 

--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -55,7 +55,7 @@ class ApiController extends StatamicApiController
             throw new NotFoundHttpException;
         }
 
-        if (! $model = $resource->model()->runwayStatus('published')->find($model)) {
+        if (! $model = $resource->model()->whereStatus('published')->find($model)) {
             throw new NotFoundHttpException;
         }
 

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -72,6 +72,7 @@ class ResourceController extends CpController
             'meta' => $fields->meta(),
             'permalink' => null,
             'resourceHasRoutes' => $resource->hasRouting(),
+            'canManagePublishState' => $resource->hasPublishStates(),
         ];
 
         if ($request->wantsJson()) {
@@ -153,6 +154,7 @@ class ResourceController extends CpController
                 'title' => $model->{$resource->titleField()},
                 'edit_url' => $request->url(),
             ],
+            'canManagePublishState' => $resource->hasPublishStates(),
             'itemActions' => Action::for($model, ['resource' => $resource->handle(), 'view' => 'form']),
         ];
 

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -196,6 +196,8 @@ class ResourceController extends CpController
     {
         return array_merge($model->toArray(), [
             'title' => $model->{$resource->titleField()},
+            'published' => $model->{$resource->publishedColumn()},
+            'status' => $model->publishedStatus(),
             'edit_url' => cp_route('runway.edit', [
                 'resource' => $resource->handle(),
                 'model' => $model->{$resource->routeKey()},

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -80,6 +80,7 @@ class ResourceController extends CpController
             'permalink' => null,
             'resourceHasRoutes' => $resource->hasRouting(),
             'canManagePublishState' => $resource->hasPublishStates(),
+            'publishedColumn' => $resource->publishedColumn(),
         ];
 
         if ($request->wantsJson()) {
@@ -162,6 +163,7 @@ class ResourceController extends CpController
                 'edit_url' => $request->url(),
             ],
             'canManagePublishState' => $resource->hasPublishStates(),
+            'publishedColumn' => $resource->publishedColumn(),
             'itemActions' => Action::for($model, ['resource' => $resource->handle(), 'view' => 'form']),
         ];
 

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -75,7 +75,9 @@ class ResourceController extends CpController
             ],
             'resource' => $request->wantsJson() ? $resource->toArray() : $resource,
             'blueprint' => $blueprint->toPublishArray(),
-            'values' => $fields->values(),
+            'values' => $fields->values()->merge([
+                $resource->publishedColumn() => true,
+            ])->all(),
             'meta' => $fields->meta(),
             'permalink' => null,
             'resourceHasRoutes' => $resource->hasRouting(),

--- a/src/Http/Controllers/CP/Traits/ExtractsFromModelFields.php
+++ b/src/Http/Controllers/CP/Traits/ExtractsFromModelFields.php
@@ -20,6 +20,11 @@ trait ExtractsFromModelFields
             ->addValues($values->all())
             ->preProcess();
 
-        return [$fields->values()->merge(['id' => $model->getKey()])->all(), $fields->meta()->all()];
+        $values = $fields->values()->merge([
+            'id' => $model->getKey(),
+            'published' => $model->{$resource->publishedColumn()},
+        ]);
+
+        return [$values->all(), $fields->meta()->all()];
     }
 }

--- a/src/Http/Controllers/CP/Traits/ExtractsFromModelFields.php
+++ b/src/Http/Controllers/CP/Traits/ExtractsFromModelFields.php
@@ -22,7 +22,7 @@ trait ExtractsFromModelFields
 
         $values = $fields->values()->merge([
             'id' => $model->getKey(),
-            'published' => $model->{$resource->publishedColumn()},
+            $resource->publishedColumn() => $model->{$resource->publishedColumn()},
         ]);
 
         return [$values->all(), $fields->meta()->all()];

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -80,7 +80,7 @@ trait PreparesModels
         $blueprint = $resource->blueprint();
 
         $blueprint
-            ->ensureField('published', ['type' => 'toggle'])
+            ->ensureField($resource->publishedColumn(), ['type' => 'toggle'])
             ->fields()
             ->setParent($model)
             ->all()

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -79,8 +79,11 @@ trait PreparesModels
     {
         $blueprint = $resource->blueprint();
 
+        if ($resource->hasPublishStates()) {
+            $blueprint->ensureField($resource->publishedColumn(), ['type' => 'toggle']);
+        }
+
         $blueprint
-            ->ensureField($resource->publishedColumn(), ['type' => 'toggle'])
             ->fields()
             ->setParent($model)
             ->all()

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -79,15 +79,14 @@ trait PreparesModels
     {
         $blueprint = $resource->blueprint();
 
-        if ($resource->hasPublishStates()) {
-            $blueprint->ensureField($resource->publishedColumn(), ['type' => 'toggle']);
-        }
-
         $blueprint
             ->fields()
             ->setParent($model)
             ->all()
             ->filter(fn (Field $field) => $this->shouldSaveField($field))
+            ->when($resource->hasPublishStates(), function ($collection) use ($resource) {
+                $collection->put($resource->publishedColumn(), new Field($resource->publishedColumn(), ['type' => 'toggle']));
+            })
             ->each(function (Field $field) use ($resource, &$model, $request) {
                 $processedValue = $field->fieldtype()->process($request->get($field->handle()));
 

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -79,7 +79,11 @@ trait PreparesModels
     {
         $blueprint = $resource->blueprint();
 
-        $blueprint->fields()->setParent($model)->all()
+        $blueprint
+            ->ensureField('published', ['type' => 'toggle'])
+            ->fields()
+            ->setParent($model)
+            ->all()
             ->filter(fn (Field $field) => $this->shouldSaveField($field))
             ->each(function (Field $field) use ($resource, &$model, $request) {
                 $processedValue = $field->fieldtype()->process($request->get($field->handle()));

--- a/src/Http/Resources/CP/ListedModel.php
+++ b/src/Http/Resources/CP/ListedModel.php
@@ -43,6 +43,8 @@ class ListedModel extends JsonResource
 
         return [
             'id' => $model->getKey(),
+            'published' => $this->resource->{$this->runwayResource->publishedColumn()},
+            'status' => $this->resource->publishedStatus(),
             'edit_url' => cp_route('runway.edit', ['resource' => $this->runwayResource->handle(), 'model' => $model->getRouteKey()]),
             'permalink' => $this->runwayResource->hasRouting() ? $model->uri() : null,
             'editable' => User::current()->can('edit', [$this->runwayResource, $model]),

--- a/src/Http/Resources/CP/Models.php
+++ b/src/Http/Resources/CP/Models.php
@@ -50,6 +50,17 @@ class Models extends ResourceCollection
             return $column;
         });
 
+        if ($this->runwayResource->hasPublishStates()) {
+            $status = Column::make('status')
+                ->listable(true)
+                ->visible(true)
+                ->defaultVisibility(true)
+                ->defaultOrder($columns->count() + 1)
+                ->sortable(false);
+
+            $columns->put('status', $status);
+        }
+
         if ($key = $this->columnPreferenceKey) {
             $columns->setPreferred($key);
         }

--- a/src/Query/Scopes/Filters/Status.php
+++ b/src/Query/Scopes/Filters/Status.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace StatamicRadPack\Runway\Query\Scopes\Filters;
+
+use Illuminate\Support\Collection;
+use Statamic\Query\Scopes\Filters\Status as BaseStatusFilter;
+use StatamicRadPack\Runway\Resource;
+use StatamicRadPack\Runway\Runway;
+
+class Status extends BaseStatusFilter
+{
+    public function visibleTo($key): bool
+    {
+        return in_array($key, ['runway']) && $this->resource()->hasPublishStates();
+    }
+
+    protected function options(): Collection
+    {
+        return collect([
+            'published' => __('Published'),
+            //            'scheduled' => __('Scheduled'),
+            //            'expired' => __('Expired'),
+            'draft' => __('Draft'),
+        ]);
+    }
+
+    protected function resource(): Resource
+    {
+        return Runway::findResource($this->context['resource']);
+    }
+}

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -131,6 +131,18 @@ class Resource
             ->first();
     }
 
+    public function hasPublishStates(): bool
+    {
+        return $this->config->has('published');
+    }
+
+    public function publishedColumn(): string
+    {
+        return is_string($this->config->get('published'))
+            ? $this->config->get('published')
+            : 'published';
+    }
+
     /**
      * Maps Eloquent relationships to their respective blueprint fields.
      */

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -138,8 +138,12 @@ class Resource
         return $this->config->has('published');
     }
 
-    public function publishedColumn(): string
+    public function publishedColumn(): ?string
     {
+        if (! $this->hasPublishStates()) {
+            return null;
+        }
+
         return is_string($this->config->get('published'))
             ? $this->config->get('published')
             : 'published';

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -126,7 +126,9 @@ class Resource
             ->reject(function ($handle) {
                 $field = $this->blueprint()->field($handle);
 
-                return $field->fieldtype()->indexComponent() === 'relationship' || $field->type() === 'section';
+                return $field->fieldtype()->indexComponent() === 'relationship'
+                    || $field->type() === 'section'
+                    || $field->handle() === 'published';
             })
             ->first();
     }

--- a/src/Routing/ResourceRoutingRepository.php
+++ b/src/Routing/ResourceRoutingRepository.php
@@ -12,6 +12,10 @@ class ResourceRoutingRepository
             return null;
         }
 
+        if ($runwayUri->model->runwayResource()->hasPublishStates() && $runwayUri->model->publishedStatus() !== 'published') {
+            return null;
+        }
+
         return $runwayUri->model->routingModel();
     }
 }

--- a/src/Search/Provider.php
+++ b/src/Search/Provider.php
@@ -44,7 +44,7 @@ class Provider extends BaseProvider
             ->flatMap(function ($items, $handle) {
                 $ids = $items->map(fn ($item) => Str::after($item, '::'));
 
-                return Runway::findResource($handle)->model()->find($ids);
+                return Runway::findResource($handle)->model()->runwayStatus('published')->find($ids);
             })
             ->mapInto(Searchable::class);
     }

--- a/src/Search/Provider.php
+++ b/src/Search/Provider.php
@@ -21,7 +21,7 @@ class Provider extends BaseProvider
             return Runway::findResource($handle)
                 ->model()
                 ->query()
-                ->runwayStatus('published')
+                ->whereStatus('published')
                 ->get()
                 ->mapInto(Searchable::class);
         })->filter($this->filter());
@@ -49,7 +49,7 @@ class Provider extends BaseProvider
             ->flatMap(function ($items, $handle) {
                 $ids = $items->map(fn ($item) => Str::after($item, '::'));
 
-                return Runway::findResource($handle)->model()->runwayStatus('published')->find($ids);
+                return Runway::findResource($handle)->model()->whereStatus('published')->find($ids);
             })
             ->mapInto(Searchable::class);
     }

--- a/src/Search/Provider.php
+++ b/src/Search/Provider.php
@@ -18,7 +18,12 @@ class Provider extends BaseProvider
         $resources = $this->usesWildcard() ? Runway::allResources()->keys() : $this->keys;
 
         return collect($resources)->flatMap(function ($handle) {
-            return Runway::findResource($handle)->model()->all()->mapInto(Searchable::class);
+            return Runway::findResource($handle)
+                ->model()
+                ->query()
+                ->runwayStatus('published')
+                ->get()
+                ->mapInto(Searchable::class);
         })->filter($this->filter());
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -30,6 +30,8 @@ class ServiceProvider extends AddonServiceProvider
     protected $actions = [
         Actions\DeleteModel::class,
         Actions\DuplicateModel::class,
+        Actions\Publish::class,
+        Actions\Unpublish::class,
     ];
 
     protected $commands = [

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -51,6 +51,7 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $scopes = [
         Query\Scopes\Filters\Fields::class,
+        Query\Scopes\Filters\Status::class,
     ];
 
     protected $tags = [

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -29,6 +29,11 @@ class RunwayTag extends Tags
 
         $query = $resource->model()->query()
             ->when(
+                $this->params->get('status'),
+                fn ($query, $status) => $query->runwayStatus($status),
+                fn ($query) => $query->runwayStatus('published')
+            )
+            ->when(
                 $this->params->get('with'),
                 fn ($query) => $query->with(explode('|', (string) $this->params->get('with'))),
                 fn ($query) => $query->with($resource->eagerLoadingRelationships())

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -30,8 +30,8 @@ class RunwayTag extends Tags
         $query = $resource->model()->query()
             ->when(
                 $this->params->get('status'),
-                fn ($query, $status) => $query->runwayStatus($status),
-                fn ($query) => $query->runwayStatus('published')
+                fn ($query, $status) => $query->whereStatus($status),
+                fn ($query) => $query->whereStatus('published')
             )
             ->when(
                 $this->params->get('with'),

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -66,4 +66,26 @@ trait HasRunwayResource
 
         return 'published';
     }
+
+    public function scopeRunwayStatus(Builder $query, string $status): void
+    {
+        if (! $this->runwayResource()->hasPublishStates()) {
+            return;
+        }
+
+        switch ($status) {
+            case 'published':
+                $query->where($this->runwayResource()->publishedColumn(), true);
+                break;
+            case 'draft':
+                $query->where($this->runwayResource()->publishedColumn(), false);
+                break;
+            case 'scheduled':
+                throw new \Exception("Runway doesn't currently support the [scheduled] status.");
+            case 'expired':
+                throw new \Exception("Runway doesn't currently support the [expired] status.");
+            default:
+                throw new \Exception("Invalid status [$status]");
+        }
+    }
 }

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -67,7 +67,7 @@ trait HasRunwayResource
         return 'published';
     }
 
-    public function scopeRunwayStatus(Builder $query, string $status): void
+    public function scopeWhereStatus(Builder $query, string $status): void
     {
         if (! $this->runwayResource()->hasPublishStates()) {
             return;
@@ -87,11 +87,6 @@ trait HasRunwayResource
             default:
                 throw new \Exception("Invalid status [$status]");
         }
-    }
-
-    public function scopeWhereStatus(Builder $query, string $status): void
-    {
-        $this->scopeRunwayStatus($query, $status);
     }
 
     public function resolveGqlValue($field)

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -53,4 +53,17 @@ trait HasRunwayResource
             })
             ->each(fn (Field $field) => $query->orWhere($field->handle(), 'LIKE', '%'.$searchQuery.'%'));
     }
+
+    public function publishedStatus(): ?string
+    {
+        if (! $this->runwayResource()->hasPublishStates()) {
+            return null;
+        }
+
+        if (! $this->{$this->runwayResource()->publishedColumn()}) {
+            return 'draft';
+        }
+
+        return 'published';
+    }
 }

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -88,4 +88,18 @@ trait HasRunwayResource
                 throw new \Exception("Invalid status [$status]");
         }
     }
+
+    public function scopeWhereStatus(Builder $query, string $status): void
+    {
+        $this->scopeRunwayStatus($query, $status);
+    }
+
+    public function resolveGqlValue($field)
+    {
+        if ($this->runwayResource()->handle() && $field === 'status') {
+            return $this->publishedStatus();
+        }
+
+        return $this->traitResolveGqlValue($field);
+    }
 }

--- a/tests/Actions/PublishTest.php
+++ b/tests/Actions/PublishTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace StatamicRadPack\Runway\Tests\Actions;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Role;
+use Statamic\Facades\User;
+use StatamicRadPack\Runway\Actions\DeleteModel;
+use StatamicRadPack\Runway\Actions\Publish;
+use StatamicRadPack\Runway\Runway;
+use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
+use StatamicRadPack\Runway\Tests\TestCase;
+
+class PublishTest extends TestCase
+{
+    /** @test */
+    public function it_returns_title()
+    {
+        $this->assertEquals('Publish', Publish::title());
+    }
+
+    /** @test */
+    public function is_visible_to_eloquent_model()
+    {
+        $visibleTo = (new Publish())->context([])->visibleTo(Post::factory()->unpublished()->create());
+
+        $this->assertTrue($visibleTo);
+    }
+
+    /** @test */
+    public function is_not_visible_to_published_eloquent_model()
+    {
+        $visibleTo = (new Publish())->context([])->visibleTo(Post::factory()->create());
+
+        $this->assertFalse($visibleTo);
+    }
+
+    /** @test */
+    public function is_not_visible_to_eloquent_model_when_resource_is_read_only()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.read_only', true);
+        Runway::discoverResources();
+
+        $visibleTo = (new Publish())->context([])->visibleTo(Post::factory()->unpublished()->create());
+
+        $this->assertFalse($visibleTo);
+    }
+
+    /** @test */
+    public function is_not_visible_to_entry()
+    {
+        Collection::make('posts')->save();
+
+        $visibleTo = (new Publish())->context([])->visibleTo(
+            tap(Entry::make()->collection('posts')->slug('hello-world'))->save()
+        );
+
+        $this->assertFalse($visibleTo);
+    }
+
+    /** @test */
+    public function is_visible_to_eloquent_models_in_bulk()
+    {
+        $posts = Post::factory()->count(3)->unpublished()->create();
+
+        $visibleToBulk = (new Publish())->context([])->visibleToBulk($posts);
+
+        $this->assertTrue($visibleToBulk);
+    }
+
+    /** @test */
+    public function is_not_visible_to_eloquent_models_in_bulk_when_not_all_models_are_unpublished()
+    {
+        $posts = Post::factory()->count(3)->unpublished()->create();
+        $posts->first()->update(['published' => true]);
+
+        $visibleToBulk = (new Publish())->context([])->visibleToBulk($posts);
+
+        $this->assertFalse($visibleToBulk);
+    }
+
+    /** @test */
+    public function super_user_is_authorized()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $authorize = (new Publish())->authorize($user, Post::factory()->create());
+
+        $this->assertTrue($authorize);
+    }
+
+    /** @test */
+    public function user_with_permission_is_authorized()
+    {
+        Role::make('editor')->addPermission('edit post')->save();
+
+        $user = User::make()->assignRole('editor')->save();
+
+        $authorize = (new Publish())->authorize($user, Post::factory()->create());
+
+        $this->assertTrue($authorize);
+
+        Role::find('editor')->delete();
+    }
+
+    /** @test */
+    public function user_without_permission_is_not_authorized()
+    {
+        $user = User::make()->save();
+
+        $authorize = (new Publish())->authorize($user, Post::factory()->create());
+
+        $this->assertFalse($authorize);
+    }
+
+    /** @test */
+    public function it_publishes_models()
+    {
+        $posts = Post::factory()->count(5)->unpublished()->create();
+
+        $posts->each(fn (Post $post) => $this->assertFalse($post->published));
+
+        (new Publish)->run($posts, []);
+
+        $posts->each(fn (Post $post) => $this->assertTrue($post->published));
+    }
+}

--- a/tests/Actions/UnpublishTest.php
+++ b/tests/Actions/UnpublishTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace StatamicRadPack\Runway\Tests\Actions;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Role;
+use Statamic\Facades\User;
+use StatamicRadPack\Runway\Actions\DeleteModel;
+use StatamicRadPack\Runway\Actions\Publish;
+use StatamicRadPack\Runway\Actions\Unpublish;
+use StatamicRadPack\Runway\Runway;
+use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
+use StatamicRadPack\Runway\Tests\TestCase;
+
+class UnpublishTest extends TestCase
+{
+    /** @test */
+    public function it_returns_title()
+    {
+        $this->assertEquals('Unpublish', Unpublish::title());
+    }
+
+    /** @test */
+    public function is_visible_to_eloquent_model()
+    {
+        $visibleTo = (new Unpublish())->context([])->visibleTo(Post::factory()->create());
+
+        $this->assertTrue($visibleTo);
+    }
+
+    /** @test */
+    public function is_not_visible_to_unpublished_eloquent_model()
+    {
+        $visibleTo = (new Unpublish())->context([])->visibleTo(Post::factory()->unpublished()->create());
+
+        $this->assertFalse($visibleTo);
+    }
+
+    /** @test */
+    public function is_not_visible_to_eloquent_model_when_resource_is_read_only()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.read_only', true);
+        Runway::discoverResources();
+
+        $visibleTo = (new Unpublish())->context([])->visibleTo(Post::factory()->create());
+
+        $this->assertFalse($visibleTo);
+    }
+
+    /** @test */
+    public function is_not_visible_to_entry()
+    {
+        Collection::make('posts')->save();
+
+        $visibleTo = (new Unpublish())->context([])->visibleTo(
+            tap(Entry::make()->collection('posts')->slug('hello-world'))->save()
+        );
+
+        $this->assertFalse($visibleTo);
+    }
+
+    /** @test */
+    public function is_visible_to_eloquent_models_in_bulk()
+    {
+        $posts = Post::factory()->count(3)->create();
+
+        $visibleToBulk = (new Unpublish())->context([])->visibleToBulk($posts);
+
+        $this->assertTrue($visibleToBulk);
+    }
+
+    /** @test */
+    public function is_not_visible_to_eloquent_models_in_bulk_when_not_all_models_are_published()
+    {
+        $posts = Post::factory()->count(3)->create();
+        $posts->first()->update(['published' => false]);
+
+        $visibleToBulk = (new Unpublish())->context([])->visibleToBulk($posts);
+
+        $this->assertFalse($visibleToBulk);
+    }
+
+    /** @test */
+    public function super_user_is_authorized()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $authorize = (new Unpublish())->authorize($user, Post::factory()->create());
+
+        $this->assertTrue($authorize);
+    }
+
+    /** @test */
+    public function user_with_permission_is_authorized()
+    {
+        Role::make('editor')->addPermission('edit post')->save();
+
+        $user = User::make()->assignRole('editor')->save();
+
+        $authorize = (new Unpublish())->authorize($user, Post::factory()->create());
+
+        $this->assertTrue($authorize);
+
+        Role::find('editor')->delete();
+    }
+
+    /** @test */
+    public function user_without_permission_is_not_authorized()
+    {
+        $user = User::make()->save();
+
+        $authorize = (new Unpublish())->authorize($user, Post::factory()->create());
+
+        $this->assertFalse($authorize);
+    }
+
+    /** @test */
+    public function it_publishes_models()
+    {
+        $posts = Post::factory()->count(5)->create();
+
+        $posts->each(fn (Post $post) => $this->assertTrue($post->published));
+
+        (new Unpublish)->run($posts, []);
+
+        $posts->each(fn (Post $post) => $this->assertFalse($post->published));
+    }
+}

--- a/tests/Http/Controllers/CP/ResourceActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceActionControllerTest.php
@@ -47,7 +47,7 @@ class ResourceActionControllerTest extends TestCase
                 'selections' => [$post->id],
             ])
             ->assertOk()
-            ->assertJsonPath('0.handle', 'delete_model');
+            ->assertJsonPath('0.handle', 'unpublish');
     }
 }
 

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -68,6 +68,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->post(cp_route('runway.store', ['resource' => 'post']), [
+                'published' => true,
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -120,6 +121,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->post(cp_route('runway.store', ['resource' => 'post']), [
+                'published' => true,
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -148,6 +150,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->post(cp_route('runway.store', ['resource' => 'post']), [
+                'published' => true,
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -176,6 +179,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->post(cp_route('runway.store', ['resource' => 'post']), [
+                'published' => true,
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -204,6 +208,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->post(cp_route('runway.store', ['resource' => 'post']), [
+                'published' => true,
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -497,6 +502,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
+                'published' => true,
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -524,6 +530,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
+                'published' => true,
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -574,6 +581,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
+                'published' => true,
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -602,6 +610,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
+                'published' => true,
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -630,6 +639,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
+                'published' => true,
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -658,6 +668,7 @@ class ResourceControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
+                'published' => true,
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,

--- a/tests/Routing/ResourceRoutingRepositoryTest.php
+++ b/tests/Routing/ResourceRoutingRepositoryTest.php
@@ -54,4 +54,17 @@ class ResourceRoutingRepositoryTest extends TestCase
 
         $this->assertNull($findByUri);
     }
+
+    /** @test */
+    public function cant_find_by_uri_when_model_is_unpublished()
+    {
+        $post = Post::factory()->unpublished()->create();
+        $runwayUri = $post->fresh()->runwayUri;
+
+        $this->assertEquals($runwayUri->uri, "/posts/{$post->slug}");
+
+        $findByUri = Data::findByUri("/posts/{$post->slug}");
+
+        $this->assertNull($findByUri);
+    }
 }

--- a/tests/Search/ProviderTest.php
+++ b/tests/Search/ProviderTest.php
@@ -30,6 +30,23 @@ class ProviderTest extends TestCase
         $this->assertEquals("runway::post::{$posts[4]->id}", $models[4]->getSearchReference());
     }
 
+    /** @test */
+    public function it_filters_out_unpublished_models()
+    {
+        $publishedModels = Post::factory()->count(2)->create();
+        Post::factory()->count(2)->unpublished()->create();
+
+        $provider = $this->makeProvider('en', ['searchables' => ['post']]);
+        $models = $provider->provide();
+
+        $this->assertCount(2, $models);
+
+        $this->assertEquals([
+            "runway::post::{$publishedModels[0]->id}",
+            "runway::post::{$publishedModels[1]->id}",
+        ], $models->map->getSearchReference()->all());
+    }
+
     private function makeProvider($locale, $config)
     {
         $index = $this->makeIndex($locale, $config);

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -15,7 +15,7 @@ class Post extends Model
     use HasFactory, HasRunwayResource, RunwayRoutes;
 
     protected $fillable = [
-        'title', 'slug', 'body', 'values', 'external_links', 'author_id', 'sort_order',
+        'title', 'slug', 'body', 'values', 'external_links', 'author_id', 'sort_order', 'published',
     ];
 
     protected $appends = [
@@ -26,6 +26,7 @@ class Post extends Model
     protected $casts = [
         'values' => 'array',
         'external_links' => 'object',
+        'published' => 'boolean',
     ];
 
     public function scopeFood($query)

--- a/tests/__fixtures__/config/runway.php
+++ b/tests/__fixtures__/config/runway.php
@@ -18,6 +18,7 @@ return [
                 ],
             ],
             'route' => '/posts/{{ slug }}',
+            'published' => true,
         ],
 
         Author::class => [

--- a/tests/__fixtures__/database/factories/PostFactory.php
+++ b/tests/__fixtures__/database/factories/PostFactory.php
@@ -28,6 +28,14 @@ class PostFactory extends Factory
             'slug' => Str::slug($title),
             'body' => implode(' ', $this->faker->paragraphs(10)),
             'author_id' => Author::factory()->create()->id,
+            'published' => true,
         ];
+    }
+
+    public function unpublished()
+    {
+        return $this->state([
+            'published' => false,
+        ]);
     }
 }

--- a/tests/__fixtures__/database/migrations/2020_12_12_220453_create_posts_table.php
+++ b/tests/__fixtures__/database/migrations/2020_12_12_220453_create_posts_table.php
@@ -24,6 +24,7 @@ class CreatePostsTable extends Migration
             $table->integer('sort_order')->nullable();
             $table->datetime('start_date')->nullable();
             $table->datetime('end_date')->nullable();
+            $table->boolean('published')->default(false);
             $table->timestamps();
         });
     }


### PR DESCRIPTION
This pull request adds the ability to mark models as published & unpublished, with all the expected filtering of unpublished models in Antlers, the GraphQL API, Search, etc.

This might come in useful if you're using Runway to store some kind of content and you don't want to have to do all the filtering etc yourself.

To enable, simply add the `published` config option to a resource's config array, and either set it to `true` (which will assume the model has a `published` boolean column) or another column of your choosing.

```php
'resources' => [
	\App\Models\Order::class => [
	    'name' => 'Orders',
		'published' => true,
		'published' => 'active',
	],
],
```

This PR will be helpful when we introduce support for Revisions, which is coming soon, see #492.

Related: https://github.com/statamic-rad-pack/runway/discussions/294