### PR TITLE
[7.x] Improve page titles

### DIFF
--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -285,6 +285,13 @@ export default {
         saving(saving) {
             this.$progress.loading(`runway-publish-form`, saving)
         },
+
+        title(title) {
+            if (this.isBase) {
+                const arrow = this.direction === 'ltr' ? '‹' : '›';
+                document.title = `${title} ${arrow} ${this.breadcrumbs[0].text} ${arrow} ${__('Statamic')}`;
+            }
+        },
     },
 
     methods: {
@@ -355,8 +362,6 @@ export default {
                 })
                 .then(() => {
                     let nextAction = this.quickSave ? 'continue_editing' : this.afterSaveOption;
-
-                    console.log(nextAction)
 
                     // If the user has opted to create another entry, redirect them to create page.
                     if (!this.isInline && nextAction === 'create_another') {

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -1,8 +1,6 @@
 @inject('str', 'Statamic\Support\Str')
 @extends('statamic::layout')
-@section('title', __('Create :resource', [
-    'resource' => $resource->singular(),
-]))
+@section('title', $breadcrumbs->title(__('Create :resource', ['resource' => $resource->singular()])))
 @section('wrapper_class', 'max-w-3xl')
 
 @section('content')

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -1,8 +1,6 @@
 @inject('str', 'Statamic\Support\Str')
 @extends('statamic::layout')
-@section('title', __('Edit :resource', [
-    'resource' => $resource->singular(),
-]))
+@section('title', $breadcrumbs->title($title))
 @section('wrapper_class', 'max-w-3xl')
 
 @section('content')


### PR DESCRIPTION
This pull request improves the page `<title>`s on Publish Form pages.

Previously, they were just "Create Post" or "Edit Post". However, this PR makes them more like entries and changes them to "Post Title < Posts".