### PR TITLE
[7.x] Only show the sidebar when it's needed

### DIFF
--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -77,6 +77,7 @@
 
                 <publish-tabs
                     :read-only="readOnly"
+                    :enable-sidebar="sidebarEnabled"
                     @updated="setFieldValue"
                     @meta-updated="setFieldMeta"
                     @focus="$refs.container.$emit('focus', $event)"
@@ -365,6 +366,12 @@ export default {
 
         direction() {
             return this.$config.get('direction', 'ltr');
+        },
+
+        sidebarEnabled() {
+            let hasSidebarTab = this.blueprint.tabs.filter((tab) => tab.handle === 'sidebar').length > 0
+
+            return this.resourceHasRoutes || this.publishStatesEnabled || hasSidebarTab
         },
     },
 


### PR DESCRIPTION
This pull request fixes an issue where an empty sidebar would be rendered, even when the blueprint contains no "sidebar" tab. 

![CleanShot 2024-06-06 at 11 55 06](https://github.com/statamic-rad-pack/runway/assets/19637309/01eca05a-caea-44f6-926f-33aeb15ab0d7)
