### PR TITLE
[7.x] Fix broken Has Many fieldtype when used outside of resources

### DIFF
--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -4,6 +4,7 @@ namespace StatamicRadPack\Runway\Fieldtypes;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Arr;
 use Statamic\Facades\Blink;
 use Statamic\Facades\GraphQL;
 use StatamicRadPack\Runway\Runway;
@@ -55,7 +56,7 @@ class HasManyFieldtype extends BaseFieldtype
         $resourceHandle = request()->route('resource');
 
         if (! $resourceHandle) {
-            return $data;
+            return Arr::wrap($data);
         }
 
         return collect($data)


### PR DESCRIPTION
This pull request fixes an issue with the Has Many fieldtype where the Create/Link buttons wouldn't be displayed, when the fieldtype is used outside of a Runway context (eg. in an entry). 

It _might_ have been caused by statamic/cms#10272, although I haven't confirmed that.

Fixes #516.