### PR TITLE
[7.x] Allow search_indexes on resources

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -168,6 +168,19 @@ If you'd like to specify a different field, you may do so by setting the `title_
 ],
 ```
 
+### Search index
+
+Allows you to specify a [search index](https://statamic.dev/search#indexes) to be used when searching for entries in the CP listing.
+
+```php
+'resources' => [
+	\App\Models\Order::class => [
+	    'name' => 'Orders',
+		'search_index' => 'my_search_index',
+	],
+],
+```
+
 ### Eager Loading
 
 To help with performance, Runway will automatically ["eager load"](https://laravel.com/docs/master/eloquent-relationships#eager-loading) any Eloquent relationships it knows about based on the fields you've defined in your blueprint.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -168,9 +168,9 @@ If you'd like to specify a different field, you may do so by setting the `title_
 ],
 ```
 
-### Search index
+### Search Index
 
-Allows you to specify a [search index](https://statamic.dev/search#indexes) to be used when searching for entries in the CP listing.
+The `search_index` option allows you to specify a [search index](https://statamic.dev/search#indexes) which should be used when search models in the Control Panel listing table.
 
 ```php
 'resources' => [

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -11,9 +11,9 @@ use Statamic\CP\Column;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Parse;
 use Statamic\Fieldtypes\Relationship;
+use Statamic\Query\Builder as BaseStatamicBuilder;
 use StatamicRadPack\Runway\Query\Scopes\Filters\Fields\Models;
 use StatamicRadPack\Runway\Resource;
-use Statamic\Query\Builder as BaseStatamicBuilder;
 use StatamicRadPack\Runway\Runway;
 
 class BaseFieldtype extends Relationship

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Fieldtypes;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -12,6 +13,7 @@ use Statamic\Facades\Parse;
 use Statamic\Fieldtypes\Relationship;
 use StatamicRadPack\Runway\Query\Scopes\Filters\Fields\Models;
 use StatamicRadPack\Runway\Resource;
+use Statamic\Query\Builder as BaseStatamicBuilder;
 use StatamicRadPack\Runway\Runway;
 
 class BaseFieldtype extends Relationship
@@ -340,7 +342,7 @@ class BaseFieldtype extends Relationship
         return $resource->hasPublishStates();
     }
 
-    private function applySearch(Resource $resource, $query, $searchQuery)
+    private function applySearch(Resource $resource, Builder $query, string $searchQuery): Builder|BaseStatamicBuilder
     {
         if (! $searchQuery) {
             return $query;

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -346,7 +346,7 @@ class BaseFieldtype extends Relationship
             return $query;
         }
 
-        if ($resource->hasSearchIndex() && ($index == $resource->searchIndex())) {
+        if ($resource->hasSearchIndex() && ($index = $resource->searchIndex())) {
             return $index->ensureExists()->search($searchQuery);
         }
 

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -97,7 +97,7 @@ class BaseFieldtype extends Relationship
 
         $query = $this->applySearch($resource, $query, $searchQuery);
 
-        $query->when($query->getQuery()->orders, function ($query) use ($request, $resource) {
+        $query->when(method_exists($query, 'getQuery') && $query->getQuery()->orders, function ($query) use ($request, $resource) {
             if ($orderBy = $request->input('sort')) {
                 // The stack selector always uses `title` as the default sort column, but
                 // the "title field" for the model might be a different column so we need to convert it.
@@ -112,7 +112,7 @@ class BaseFieldtype extends Relationship
             : $query->get();
 
         if ($searchQuery && $resource->hasSearchIndex()) {
-            $results->setCollection($results->getCollection()->map(fn ($item) => $item->getSearchable()->model()));
+            $items->setCollection($items->getCollection()->map(fn ($item) => $item->getSearchable()->model()));
         }
 
         $items

--- a/src/Http/Controllers/CP/ResourceListingController.php
+++ b/src/Http/Controllers/CP/ResourceListingController.php
@@ -63,7 +63,7 @@ class ResourceListingController extends CpController
             return $query;
         }
 
-        if ($resource->hasSearchIndex() && ($index == $resource->searchIndex())) {
+        if ($resource->hasSearchIndex() && ($index = $resource->searchIndex())) {
             return $index->ensureExists()->search($searchQuery);
         }
 

--- a/src/Http/Controllers/CP/ResourceListingController.php
+++ b/src/Http/Controllers/CP/ResourceListingController.php
@@ -6,10 +6,10 @@ use Illuminate\Database\Eloquent\Builder;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
+use Statamic\Query\Builder as BaseStatamicBuilder;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use StatamicRadPack\Runway\Http\Resources\CP\Models;
 use StatamicRadPack\Runway\Resource;
-use Statamic\Query\Builder as BaseStatamicBuilder;
 
 class ResourceListingController extends CpController
 {

--- a/src/Http/Controllers/CP/ResourceListingController.php
+++ b/src/Http/Controllers/CP/ResourceListingController.php
@@ -2,12 +2,14 @@
 
 namespace StatamicRadPack\Runway\Http\Controllers\CP;
 
+use Illuminate\Database\Eloquent\Builder;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use StatamicRadPack\Runway\Http\Resources\CP\Models;
 use StatamicRadPack\Runway\Resource;
+use Statamic\Query\Builder as BaseStatamicBuilder;
 
 class ResourceListingController extends CpController
 {
@@ -57,7 +59,7 @@ class ResourceListingController extends CpController
             ]);
     }
 
-    private function applySearch(Resource $resource, $query, $searchQuery)
+    private function applySearch(Resource $resource, Builder $query, string $searchQuery): Builder|BaseStatamicBuilder
     {
         if (! $searchQuery) {
             return $query;

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Statamic\Facades\Search;
 use Statamic\Fields\Blueprint;
 use Statamic\Fields\Field;
 use Statamic\Statamic;
@@ -245,6 +246,20 @@ class Resource
         }
 
         return $this->config->get('revisions', false);
+    }
+
+    public function searchIndex()
+    {
+        if (! $index = $this->config->get('search_index', false)) {
+            return;
+        }
+
+        return Search::index($index);
+    }
+
+    public function hasSearchIndex()
+    {
+        return $this->searchIndex() !== null;
     }
 
     public function toArray(): array

--- a/src/Search/Searchable.php
+++ b/src/Search/Searchable.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Search;
 
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Contracts\Query\ContainsQueryableValues;
@@ -23,11 +24,21 @@ class Searchable implements Augmentable, ContainsQueryableValues, Contract
 
     protected $resource;
 
-    public function __construct($model)
+    public function __construct(Model $model)
     {
         $this->model = $model;
         $this->resource = Runway::findResourceByModel($model);
         $this->supplements = collect();
+    }
+
+    public function get($key, $fallback = null)
+    {
+        return $this->model->{$key} ?? $fallback;
+    }
+
+    public function model(): Model
+    {
+        return $this->model;
     }
 
     public function resource(): Resource

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -208,7 +208,7 @@ class HasManyFieldtypeTest extends TestCase
         Config::set('statamic.search.indexes.test_search_index', [
             'driver' => 'local',
             'searchables' => ['runway:post'],
-            'fields' => ['name', 'slug'],
+            'fields' => ['title', 'slug'],
         ]);
 
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.search_index', 'test_search_index');

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -203,6 +203,36 @@ class HasManyFieldtypeTest extends TestCase
     }
 
     /** @test */
+    public function can_get_index_items_and_search_using_a_search_index()
+    {
+        Config::set('statamic.search.indexes.test_search_index', [
+            'driver' => 'local',
+            'searchables' => ['runway:post'],
+            'fields' => ['name', 'slug'],
+        ]);
+
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.search_index', 'test_search_index');
+
+        Runway::discoverResources();
+
+        $author = Author::factory()->create();
+        Post::factory()->count(10)->create(['author_id' => $author->id]);
+        $spacePandaPosts = Post::factory()->count(3)->create(['author_id' => $author->id, 'title' => 'Space Pandas']);
+
+        $getIndexItems = $this->fieldtype->getIndexItems(
+            new FilteredRequest(['search' => 'space pan'])
+        );
+
+        $this->assertIsObject($getIndexItems);
+        $this->assertTrue($getIndexItems instanceof Paginator);
+        $this->assertEquals($getIndexItems->count(), 3);
+
+        $this->assertEquals($getIndexItems->first()['title'], $spacePandaPosts[0]->title);
+        $this->assertEquals($getIndexItems->last()['title'], $spacePandaPosts[1]->title);
+        $this->assertEquals($getIndexItems->last()['title'], $spacePandaPosts[2]->title);
+    }
+
+    /** @test */
     public function can_get_item_array_with_title_format()
     {
         $author = Author::factory()->create();

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -223,6 +223,8 @@ class ResourceListingControllerTest extends TestCase
 
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.search_index', 'test_search_index');
 
+        Runway::discoverResources();
+
         $user = User::make()->makeSuper()->save();
         $posts = Post::factory()->count(2)->create();
 

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -218,7 +218,7 @@ class ResourceListingControllerTest extends TestCase
         Config::set('statamic.search.indexes.test_search_index', [
             'driver' => 'local',
             'searchables' => ['runway:post'],
-            'fields' => ['name', 'slug'],
+            'fields' => ['title', 'slug'],
         ]);
 
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.search_index', 'test_search_index');

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -213,6 +213,37 @@ class ResourceListingControllerTest extends TestCase
     }
 
     /** @test */
+    public function can_search_using_a_search_index()
+    {
+        Config::set('statamic.search.indexes.test_search_index', [
+            'driver' => 'local',
+            'searchables' => ['runway:post'],
+            'fields' => ['name', 'slug'],
+        ]);
+
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.search_index', 'test_search_index');
+
+        $user = User::make()->makeSuper()->save();
+        $posts = Post::factory()->count(2)->create();
+
+        $posts[0]->update(['title' => 'Apple Pie']);
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('runway.listing-api', ['resource' => 'post', 'search' => 'Apple']))
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    [
+                        'title' => $posts[0]->title,
+                        'edit_url' => "http://localhost/cp/runway/post/{$posts[0]->id}",
+                        'id' => $posts[0]->id,
+                    ],
+                ],
+            ]);
+    }
+
+    /** @test */
     public function can_paginate_results()
     {
         Post::factory()->count(15)->create();


### PR DESCRIPTION
This PR adds the ability to specify a `search_index` on resources to use a Statamic search index in both the CP field type and the listing view.

Closes https://github.com/statamic-rad-pack/runway/discussions/501