### PR TITLE
[7.x] Fix "title field" when columns have been customized

### DIFF
--- a/src/Http/Controllers/CP/Traits/HasListingColumns.php
+++ b/src/Http/Controllers/CP/Traits/HasListingColumns.php
@@ -25,6 +25,7 @@ trait HasListingColumns
                     return $field->fieldtype()->indexComponent() === 'relationship' || $field->type() === 'section';
                 })
                 ->map->handle()
+                ->prepend($resource->titleField())
                 ->first();
         }
 


### PR DESCRIPTION
This pull request fixes an issue on Runway's listing table, where the `title_field` setting wouldn't take affect if the user has customized the columns being displayed.

Related: #22