### PR TITLE
[7.x] Fix Ignition Runnable Solutions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "laravel/framework": "^10.25.0 || ^11.0",
         "laravel/prompts": "^0.1.17",
         "pixelfear/composer-dist-plugin": "^0.1.5",
-        "spatie/ignition": "^1.14",
+        "spatie/ignition": "^1.15",
         "statamic/cms": "^5.7.0"
     },
     "require-dev": {

--- a/src/Exceptions/TraitMissingException.php
+++ b/src/Exceptions/TraitMissingException.php
@@ -2,19 +2,10 @@
 
 namespace StatamicRadPack\Runway\Exceptions;
 
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
-use StatamicRadPack\Runway\Ignition\Solutions\AddTraitToModel;
-
-class TraitMissingException extends \Exception implements ProvidesSolution
+class TraitMissingException extends \Exception
 {
-    public function __construct(protected string $model)
+    public function __construct(public string $model)
     {
         parent::__construct("The HasRunwayResource trait is missing from the [{$model}] model");
-    }
-
-    public function getSolution(): Solution
-    {
-        return new AddTraitToModel($this->model);
     }
 }

--- a/src/Ignition/SolutionProviders/TraitMissing.php
+++ b/src/Ignition/SolutionProviders/TraitMissing.php
@@ -6,7 +6,7 @@ use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
 use StatamicRadPack\Runway\Ignition\Solutions\AddTraitToModel;
 use Throwable;
 
-class TraitMissingException implements HasSolutionsForThrowable
+class TraitMissing implements HasSolutionsForThrowable
 {
     public function canSolve(Throwable $throwable): bool
     {

--- a/src/Ignition/SolutionProviders/TraitMissingException.php
+++ b/src/Ignition/SolutionProviders/TraitMissingException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace StatamicRadPack\Runway\Ignition\SolutionProviders;
+
+use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
+use StatamicRadPack\Runway\Ignition\Solutions\AddTraitToModel;
+use Throwable;
+
+class TraitMissingException implements HasSolutionsForThrowable
+{
+    public function canSolve(Throwable $throwable): bool
+    {
+        return $throwable instanceof \StatamicRadPack\Runway\Exceptions\TraitMissingException;
+    }
+
+    public function getSolutions(Throwable $throwable): array
+    {
+        return [new AddTraitToModel($throwable->model)];
+    }
+}

--- a/src/Ignition/Solutions/AddTraitToModel.php
+++ b/src/Ignition/Solutions/AddTraitToModel.php
@@ -9,9 +9,7 @@ use StatamicRadPack\Runway\Traits\HasRunwayResource;
 
 class AddTraitToModel implements RunnableSolution
 {
-    public function __construct(protected $model = null)
-    {
-    }
+    public function __construct(protected $model = null) {}
 
     public function getSolutionTitle(): string
     {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -20,8 +20,7 @@ class Resource
         protected Model $model,
         protected string $name,
         protected Collection $config
-    ) {
-    }
+    ) {}
 
     public function handle(): string
     {

--- a/src/Routing/ResourceResponse.php
+++ b/src/Routing/ResourceResponse.php
@@ -14,9 +14,7 @@ class ResourceResponse implements Responsable
 
     protected $with = [];
 
-    public function __construct(protected $data)
-    {
-    }
+    public function __construct(protected $data) {}
 
     public function toResponse($request)
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
@@ -9,6 +10,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
+use Spatie\ErrorSolutions\Contracts\SolutionProviderRepository;
 use Statamic\API\Middleware\Cache;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\CP\Nav;
@@ -19,6 +21,7 @@ use Statamic\Http\Middleware\RequireStatamicPro;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 use StatamicRadPack\Runway\Http\Controllers\ApiController;
+use StatamicRadPack\Runway\Ignition\SolutionProviders\TraitMissingException;
 use StatamicRadPack\Runway\Policies\ResourcePolicy;
 use StatamicRadPack\Runway\Search\Provider as SearchProvider;
 use StatamicRadPack\Runway\Search\Searchable;
@@ -88,6 +91,8 @@ class ServiceProvider extends AddonServiceProvider
             __DIR__.'/../config/runway.php' => config_path('runway.php'),
         ], 'runway-config');
 
+        $this->registerIgnitionSolutionProviders();
+
         Statamic::booted(function () {
             if ($this->shouldDiscoverResources()) {
                 Runway::discoverResources();
@@ -105,6 +110,16 @@ class ServiceProvider extends AddonServiceProvider
                 ->bootModelEventListeners()
                 ->bootDataRepository();
         });
+    }
+
+    protected function registerIgnitionSolutionProviders(): void
+    {
+        try {
+            $this->app->make(SolutionProviderRepository::class)
+                ->registerSolutionProvider(TraitMissingException::class);
+        } catch (BindingResolutionException $e) {
+            //
+        }
     }
 
     protected function registerRouteBindings(): self

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,7 +21,7 @@ use Statamic\Http\Middleware\RequireStatamicPro;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 use StatamicRadPack\Runway\Http\Controllers\ApiController;
-use StatamicRadPack\Runway\Ignition\SolutionProviders\TraitMissingException;
+use StatamicRadPack\Runway\Ignition\SolutionProviders\TraitMissing;
 use StatamicRadPack\Runway\Policies\ResourcePolicy;
 use StatamicRadPack\Runway\Search\Provider as SearchProvider;
 use StatamicRadPack\Runway\Search\Searchable;
@@ -116,7 +116,7 @@ class ServiceProvider extends AddonServiceProvider
     {
         try {
             $this->app->make(SolutionProviderRepository::class)
-                ->registerSolutionProvider(TraitMissingException::class);
+                ->registerSolutionProvider(TraitMissing::class);
         } catch (BindingResolutionException $e) {
             //
         }


### PR DESCRIPTION
This pull request fixes an issue with the "runnable solution" for the exception when the `HasRunwayResource` trait is missing from a model.

I'm not entirely sure *when* it broke - it may/may not have been caused by Ignition's recent refactor - but this PR fixes it and adjusts the minimum version of `spatie/ignition` that should be required.