### PR TITLE
[7.x] Fix inline publish forms

### DIFF
--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -555,8 +555,6 @@ export default {
          * When creating a new model via the HasMany fieldtype, pre-fill the belongs_to field to the current model.
          */
         prefillBelongsToField() {
-            this.values['from_inline_publish_form'] = true
-
             this.initialBlueprint.tabs.forEach((tab) => {
                 tab.sections.forEach((section) => {
                     section.fields

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -2,7 +2,6 @@
 
 namespace StatamicRadPack\Runway\Http\Controllers\CP;
 
-use Illuminate\Database\Eloquent\Model;
 use Statamic\CP\Breadcrumbs;
 use Statamic\CP\Column;
 use Statamic\Exceptions\NotFoundHttpException;
@@ -11,7 +10,6 @@ use Statamic\Facades\Scope;
 use Statamic\Facades\User;
 use Statamic\Fields\Field;
 use Statamic\Http\Controllers\CP\CpController;
-use StatamicRadPack\Runway\Fieldtypes\BelongsToFieldtype;
 use StatamicRadPack\Runway\Fieldtypes\HasManyFieldtype;
 use StatamicRadPack\Runway\Http\Requests\CP\CreateRequest;
 use StatamicRadPack\Runway\Http\Requests\CP\EditRequest;
@@ -20,7 +18,6 @@ use StatamicRadPack\Runway\Http\Requests\CP\StoreRequest;
 use StatamicRadPack\Runway\Http\Requests\CP\UpdateRequest;
 use StatamicRadPack\Runway\Http\Resources\CP\Model as ModelResource;
 use StatamicRadPack\Runway\Resource;
-use StatamicRadPack\Runway\Runway;
 
 class ResourceController extends CpController
 {

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -550,33 +550,6 @@ class ResourceControllerTest extends TestCase
         $this->assertEquals($post->title, 'Santa is coming home');
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/issues/187
-     */
-    public function can_update_resource_when_being_updated_from_inline_publish_form()
-    {
-        $post = Post::factory()->create();
-        $user = User::make()->makeSuper()->save();
-
-        $this
-            ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
-                'published' => true,
-                'title' => 'Santa is coming home',
-                'slug' => 'santa-is-coming-home',
-                'body' => $post->body,
-                'author_id' => [$post->author_id],
-                'from_inline_publish_form' => true,
-            ])
-            ->assertOk()
-            ->assertJsonStructure(['data', 'saved']);
-
-        $post->refresh();
-
-        $this->assertEquals($post->title, 'Santa is coming home');
-    }
-
     /** @test */
     public function cant_update_resource_if_resource_is_read_only()
     {


### PR DESCRIPTION
This pull request fixes an issue when saving inline publish forms, where you'd run into a database error due to it trying to save an array as the ID of a relationship.

It seems like this issue was being caused by some legacy code handling around inline publish forms, related to the "Table" mode which was dropped in v6 (#360).

I believe this code was how it re-populated relationship fields in the table after saving a model. Since we don't need it anymore, removing it fixes the issue.

Fixes #546.
Related: #544.