### PR TITLE
[7.x] Prevent redirect when creating model via inline publish form

### DIFF
--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -494,7 +494,7 @@ export default {
 
                         this.$nextTick(() => this.$emit('saved', response));
 
-                        if (this.isCreating) {
+                        if (!this.isInline && this.isCreating) {
                             window.location = response.data.data.edit_url + '?created=true';
                         }
                     }


### PR DESCRIPTION
This pull request fixes an issue when creating models via the Has Many / Belongs To fieldtype, where after saving the model in the inline publish form, it would redirect you to the model's edit page, instead of keeping you on the same page, like it should.