### PR TITLE
[7.x] Fix HasMany in revisions

### DIFF
--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -182,6 +182,7 @@ trait HasRunwayResource
             ->reject(fn (Field $field) => $field->fieldtype() instanceof Section)
             ->reject(fn (Field $field) => $field->visibility() === 'computed')
             ->reject(fn (Field $field) => $field->get('save', true) === false)
+            ->reject(fn (Field $field) => $field->type() === 'has_many')
             ->map->handle()
             ->values()
             ->all();

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -180,10 +180,7 @@ trait HasRunwayResource
             ->fields()
             ->setParent($this)
             ->all()
-            ->reject(fn (Field $field) => $field->fieldtype() instanceof Section)
-            ->reject(fn (Field $field) => $field->visibility() === 'computed')
-            ->reject(fn (Field $field) => $field->get('save', true) === false)
-            ->reject(fn (Field $field) => $field->type() === 'has_many')
+            ->reject(fn (Field $field) => $this->shouldReject($field))
             ->map(fn (Field $field) => Str::before($field->handle(), '->'))
             ->values()
             ->unique()
@@ -271,5 +268,16 @@ trait HasRunwayResource
     public function updateLastModified($user = false): self
     {
         return $this;
+    }
+
+    private function shouldReject(Field $field): bool
+    {
+        return match (true) {
+            $field->fieldtype() instanceof Section => true,
+            $field->visibility() === 'computed' => true,
+            $field->get('save', true) === false => true,
+            $field->type() === 'has_many' => true,
+            default => false,
+        };
     }
 }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -65,6 +65,7 @@ class ResourceTest extends TestCase
 
         $this->assertEquals([
             'author',
+            'comments',
             'runwayUri',
         ], $eagerLoadingRelationships);
     }
@@ -300,4 +301,15 @@ class ResourceTest extends TestCase
 
         $this->assertFalse($resource->revisionsEnabled());
     }
+
+    // /** @test */
+    // public function it_filters_out_proper_fields_from_revisions()
+    // {
+    //     $model = Post::factory()->create(['title' => 'Original title']);
+
+    //     tap($model->makeRevision(), function ($copy) {
+    //         $copy->message('Revision one');
+    //         $copy->date(Carbon::parse('2023-12-12 15:00:00'));
+    //     })->save();
+    // }
 }

--- a/tests/RunwayTest.php
+++ b/tests/RunwayTest.php
@@ -18,7 +18,7 @@ class RunwayTest extends TestCase
         $all = Runway::allResources()->values();
 
         $this->assertTrue($all instanceof Collection);
-        $this->assertCount(3, $all);
+        $this->assertCount(4, $all);
 
         $this->assertTrue($all[0] instanceof Resource);
         $this->assertEquals('post', $all[0]->handle());
@@ -26,14 +26,19 @@ class RunwayTest extends TestCase
         $this->assertTrue($all[0]->blueprint() instanceof Blueprint);
 
         $this->assertTrue($all[1] instanceof Resource);
-        $this->assertEquals('author', $all[1]->handle());
+        $this->assertEquals('comment', $all[1]->handle());
         $this->assertTrue($all[1]->model() instanceof Model);
         $this->assertTrue($all[1]->blueprint() instanceof Blueprint);
 
         $this->assertTrue($all[2] instanceof Resource);
-        $this->assertEquals('user', $all[2]->handle());
+        $this->assertEquals('author', $all[2]->handle());
         $this->assertTrue($all[2]->model() instanceof Model);
         $this->assertTrue($all[2]->blueprint() instanceof Blueprint);
+
+        $this->assertTrue($all[3] instanceof Resource);
+        $this->assertEquals('user', $all[3]->handle());
+        $this->assertTrue($all[3]->model() instanceof Model);
+        $this->assertTrue($all[3]->blueprint() instanceof Blueprint);
     }
 
     /** @test */

--- a/tests/__fixtures__/app/Models/Comment.php
+++ b/tests/__fixtures__/app/Models/Comment.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace StatamicRadPack\Runway\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use StatamicRadPack\Runway\Traits\HasRunwayResource;
+
+class Comment extends Model
+{
+    use HasFactory, HasRunwayResource;
+
+    protected $fillable = [
+        'comment',
+    ];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -5,6 +5,7 @@ namespace StatamicRadPack\Runway\Tests\Fixtures\Models;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Statamic\Facades\Blink;
 use StatamicRadPack\Runway\Routing\Traits\RunwayRoutes;
 use StatamicRadPack\Runway\Tests\Fixtures\Database\Factories\PostFactory;
@@ -51,6 +52,11 @@ class Post extends Model
     public function author()
     {
         return $this->belongsTo(Author::class);
+    }
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class);
     }
 
     public function excerpt(): Attribute

--- a/tests/__fixtures__/config/runway.php
+++ b/tests/__fixtures__/config/runway.php
@@ -1,6 +1,7 @@
 <?php
 
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
+use StatamicRadPack\Runway\Tests\Fixtures\Models\Comment;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\User;
 
@@ -20,6 +21,10 @@ return [
             'route' => '/posts/{{ slug }}',
             'published' => true,
             'revisions' => true,
+        ],
+
+        Comment::class => [
+            'name' => 'Comments',
         ],
 
         Author::class => [

--- a/tests/__fixtures__/database/migrations/2021_04_01_333333_create_comments_table.php
+++ b/tests/__fixtures__/database/migrations/2021_04_01_333333_create_comments_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Post::class);
+            $table->string('comment');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('authors');
+    }
+}

--- a/tests/__fixtures__/resources/blueprints/vendor/runway/comment.yaml
+++ b/tests/__fixtures__/resources/blueprints/vendor/runway/comment.yaml
@@ -1,0 +1,9 @@
+tabs:
+  main:
+    sections:
+      - fields:
+        -
+          handle: comment
+          field:
+            type: text
+            listable: true

--- a/tests/__fixtures__/resources/blueprints/vendor/runway/post.yaml
+++ b/tests/__fixtures__/resources/blueprints/vendor/runway/post.yaml
@@ -1,73 +1,64 @@
 tabs:
   main:
     sections:
-      -
-        fields:
-          -
-            handle: title
-            field:
-              type: text
-              listable: true
-          -
-            handle: slug
-            field:
-              type: slug
-          -
-            handle: body
-            field:
-              type: textarea
-          -
-            handle: values->alt_title
-            field:
-              type: text
-          -
-            handle: values->alt_body
-            field:
-              type: markdown
-          -
-            handle: external_links->links
-            field:
-              type: grid
-              fields:
-                -
-                  handle: label
-                  field:
-                    type: text
-                -
-                  handle: url
-                  field:
-                    type: text
-          -
-            handle: excerpt
-            field:
-              type: textarea
-              read_only: true
-          -
-            handle: author_id
-            field:
-              type: belongs_to
-              resource: author
-              max_items: 1
-              mode: default
-          -
-            handle: age
-            field:
-              type: integer
-              visibility: computed
-          -
-            handle: start_date
-            field:
-              type: date
-              time_enabled: true
-              validate:
-                - 'before:end_date'
-          -
-            handle: end_date
-            field:
-              type: date
-              time_enabled: true
-          -
-            handle: dont_save
-            field:
-              type: text
-              save: false
+      - fields:
+        - handle: title
+          field:
+            type: text
+            listable: true
+        - handle: slug
+          field:
+            type: slug
+        - handle: body
+          field:
+            type: textarea
+        - handle: values->alt_title
+          field:
+            type: text
+        - handle: values->alt_body
+          field:
+            type: markdown
+        - handle: external_links->links
+          field:
+            type: grid
+            fields:
+              - handle: label
+                field:
+                  type: text
+              - handle: url
+                field:
+                  type: text
+        - handle: excerpt
+          field:
+            type: textarea
+            read_only: true
+        - handle: author_id
+          field:
+            type: belongs_to
+            resource: author
+            max_items: 1
+            mode: default
+        - handle: age
+          field:
+            type: integer
+            visibility: computed
+        - handle: start_date
+          field:
+            type: date
+            time_enabled: true
+            validate:
+              - 'before:end_date'
+        - handle: end_date
+          field:
+            type: date
+            time_enabled: true
+        - handle: dont_save
+          field:
+            type: text
+            save: false
+        - handle: comments
+          field:
+            type: has_many
+            resource: comment
+            mode: default
+            always_save: true


### PR DESCRIPTION
If you have a HasMany field in the resource that is set up for revisions, it won't save properly when you publish, unless that field is filtered out.

You get this:

```
[previous exception] [object] (PDOException(code: 42S22): SQLSTATE[42S22]: Column not found: 1054 Unknown column 'updates' in 'field list' at /Users/erin/Sites/zakat/vendor/laravel/framework/src/Illuminate/Database/Connection.php:592)
[stacktrace]
#0 /Users/erin/Sites/zakat/vendor/laravel/framework/src/Illuminate/Database/Connection.php(592): PDO->prepare('update `orphans...')
#1 /Users/erin/Sites/zakat/vendor/laravel/framework/src/Illuminate/Database/Connection.php(800): Illuminate\\Database\\Connection->Illuminate\\Database\\{closure}('update `orphans...', Array)
#2 /Users/erin/Sites/zakat/vendor/laravel/framework/src/Illuminate/Database/Connection.php(767): Illuminate\\Database\\Connection->runQueryCallback('update `orphans...', Array, Object(Closure))
#3 /Users/erin/Sites/zakat/vendor/laravel/framework/src/Illuminate/Database/Connection.php(584): Illuminate\\Database\\Connection->run('update `orphans...', Array, Object(Closure))
#4 /Users/erin/Sites/zakat/vendor/laravel/framework/src/Illuminate/Database/Connection.php(536): Illuminate\\Database\\Connection->affectingStatement('update `orphans...', Array)
#5 /Users/erin/Sites/zakat/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(3722): Illuminate\\Database\\Connection->update('update `orphans...', Array)
#6 /Users/erin/Sites/zakat/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(1104): Illuminate\\Database\\Query\\Builder->update(Object(Illuminate\\Support\\Collection))
#7 /Users/erin/Sites/zakat/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1218): Illuminate\\Database\\Eloquent\\Builder->update(Array)
#8 /Users/erin/Sites/zakat/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1135): Illuminate\\Database\\Eloquent\\Model->performUpdate(Object(Illuminate\\Database\\Eloquent\\Builder))
#9 /Users/erin/Sites/zakat/vendor/statamic/cms/src/Revisions/Revisable.php(84): Illuminate\\Database\\Eloquent\\Model->save()
#10 /Users/erin/Development/runway/src/Traits/HasRunwayResource.php(241): App\\Models\\Orphan->publishWorkingCopy(Array)
#11 /Users/erin/Development/runway/src/Http/Controllers/CP/PublishedModelsController.php(21): App\\Models\\Orphan->publish(Array)
```

The SQL is:
```sql
update
  `orphans`
set
  `published` = 1,
  `story` = '[{\"type\":\"paragraph\",\"attrs\":{\"class\":null},\"content\":[{\"type\":\"text\",\"text\":\"Mohammed is a sweet boy. He was born in Dhaka city. He lost his father in 2012. Mohammed is attending school and doing great with his classes. His favorite subject is English language. He enjoys some of his free time listening to Music or playing cricket with his friends. Mohammed\'s dream is to become a doctor in the future.\"}]}]',
  `profile` = '{\"benefits\":[\"healthcare\",\"shelter\"],\"guardian\":null,\"birth_city\":null,\"report_card\":null,\"school_name\":null,\"school_grade\":null,\"benefit_other\":null,\"father_status\":null,\"mother_status\":null,\"school_address\":null,\"school_why_not\":null,\"interview_happy\":null,\"living_location\":null,\"school_attending\":false,\"school_religious\":null,\"birth_certificate\":\"sponsor-an-orphan\\/birth-certificates\\/0038-iden-c.pdf\",\"father_occupation\":null,\"fathers_full_name\":null,\"guardians_address\":null,\"interview_hobbies\":\"asdf\",\"medical_illnesses\":null,\"mother_occupation\":null,\"mothers_full_name\":null,\"orphanage_address\":null,\"guardians_relation\":null,\"medical_treatments\":null,\"number_of_siblings\":null,\"school_performance\":null,\"father_passing_date\":null,\"guardians_full_name\":null,\"mother_passing_date\":null,\"father_passing_cause\":null,\"mother_passing_cause\":null,\"guardians_phone_number\":null,\"interview_future_dreams\":\"sadf\",\"school_favorite_subject\":null,\"father_death_certificate\":null,\"interview_favorite_sport\":null,\"mother_death_certificate\":null}',
  `created_at` = '2021-11-10 00:00:00',
  `updates` = null,
  `orphans`.`updated_at` = '2024-07-05 10:20:07'
where
  `id` = 683
```

@duncanmcclean I attempted to get tests going for this and ran into some problems and I ran out of time to get them going. I can revisit in a bit, but his change finally makes revisions fully work for us.