### PR TITLE
[7.x] Prevent infinite loop when published column is missing

### DIFF
--- a/src/Exceptions/PublishedColumnMissingException.php
+++ b/src/Exceptions/PublishedColumnMissingException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace StatamicRadPack\Runway\Exceptions;
+
+class PublishedColumnMissingException extends \Exception
+{
+    public function __construct(public string $table, public string $column)
+    {
+        parent::__construct("The [{$this->column}] publish column is missing from the {$this->table} table.");
+    }
+}

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -10,6 +10,7 @@ use Statamic\Facades\Search;
 use Statamic\Fields\Blueprint;
 use Statamic\Fields\Field;
 use Statamic\Statamic;
+use StatamicRadPack\Runway\Exceptions\PublishedColumnMissingException;
 use StatamicRadPack\Runway\Fieldtypes\BelongsToFieldtype;
 use StatamicRadPack\Runway\Fieldtypes\HasManyFieldtype;
 
@@ -150,9 +151,15 @@ class Resource
             return null;
         }
 
-        return is_string($this->config->get('published'))
+        $column = is_string($this->config->get('published'))
             ? $this->config->get('published')
             : 'published';
+
+        if (! in_array($column, $this->databaseColumns())) {
+            throw new PublishedColumnMissingException($this->databaseTable(), $column);
+        }
+
+        return $column;
     }
 
     /**


### PR DESCRIPTION
This pull request prevents an infinite loop from happening when trying to load the listing table for a resource w/ publish states enabled, but without an actual `published` column in the database yet.

