### PR TITLE
[7.x] Fix incorrect revisions status

### DIFF
--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -262,7 +262,7 @@ export default {
             title: this.initialTitle,
             values: _.clone(this.initialValues),
             meta: _.clone(this.initialMeta),
-            isWorkingCopy: this.initialWorkingCopy,
+            isWorkingCopy: this.initialIsWorkingCopy,
             error: null,
             errors: {},
             state: 'new',

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -16,6 +16,7 @@
         :initial-values='@json($values)'
         :initial-meta='@json($meta)'
         initial-permalink="{{ $permalink }}"
+        :initial-is-working-copy="{{ $str::bool($hasWorkingCopy) }}"
         :initial-read-only="{{ $str::bool($readOnly) }}"
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
         :can-edit-blueprint="{{ Auth::user()->can('configure fields') ? 'true' : 'false' }}"

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -177,6 +177,7 @@ class ResourceController extends CpController
             'canManagePublishState' => User::current()->can('edit', $resource),
             'itemActions' => Action::for($model, ['resource' => $resource->handle(), 'view' => 'form']),
             'revisionsEnabled' => $resource->revisionsEnabled(),
+            'hasWorkingCopy' => $model->hasWorkingCopy(),
         ];
 
         if ($request->wantsJson()) {


### PR DESCRIPTION
This pull request fixes an issue where the "status" of revisions was incorrectly in the sidebar.

For example, if you edited a model, hit "Save", then refreshed, you'd see a "This is the published version" message, even though that isn't correct.

This was happening due to the `initial-is-working-copy` prop not being passed into the publish form, which is what that message checks against.

Fixes #551.