### PR TITLE
[7.x] Move test suite from metadata to attributes

### DIFF
--- a/tests/Actions/DeleteModelTest.php
+++ b/tests/Actions/DeleteModelTest.php
@@ -4,6 +4,7 @@ namespace StatamicRadPack\Runway\Tests\Actions;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Role;
@@ -13,7 +14,6 @@ use StatamicRadPack\Runway\Actions\DeleteModel;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class DeleteModelTest extends TestCase
 {

--- a/tests/Actions/DeleteModelTest.php
+++ b/tests/Actions/DeleteModelTest.php
@@ -13,18 +13,19 @@ use StatamicRadPack\Runway\Actions\DeleteModel;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class DeleteModelTest extends TestCase
 {
     use PreventsSavingStacheItemsToDisk;
 
-    /** @test */
+    #[Test]
     public function it_returns_title()
     {
         $this->assertEquals('Delete', DeleteModel::title());
     }
 
-    /** @test */
+    #[Test]
     public function is_visible_to_eloquent_model()
     {
         $visibleTo = (new DeleteModel())->visibleTo(Post::factory()->create());
@@ -32,7 +33,7 @@ class DeleteModelTest extends TestCase
         $this->assertTrue($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_eloquent_model_when_resource_is_read_only()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.read_only', true);
@@ -43,7 +44,7 @@ class DeleteModelTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_eloquent_model_without_a_runway_resource()
     {
         $model = new class extends Model
@@ -56,7 +57,7 @@ class DeleteModelTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_entry()
     {
         Collection::make('posts')->save();
@@ -68,7 +69,7 @@ class DeleteModelTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_visible_to_eloquent_models_in_bulk()
     {
         $posts = Post::factory()->count(3)->create();
@@ -78,7 +79,7 @@ class DeleteModelTest extends TestCase
         $this->assertTrue($visibleToBulk);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_entries_in_bulk()
     {
         Collection::make('posts')->save();
@@ -94,7 +95,7 @@ class DeleteModelTest extends TestCase
         $this->assertFalse($visibleToBulk);
     }
 
-    /** @test */
+    #[Test]
     public function super_user_is_authorized()
     {
         $user = User::make()->makeSuper()->save();
@@ -104,7 +105,7 @@ class DeleteModelTest extends TestCase
         $this->assertTrue($authorize);
     }
 
-    /** @test */
+    #[Test]
     public function user_with_permission_is_authorized()
     {
         Role::make('editor')->addPermission('delete post')->save();
@@ -118,7 +119,7 @@ class DeleteModelTest extends TestCase
         Role::find('editor')->delete();
     }
 
-    /** @test */
+    #[Test]
     public function user_without_permission_is_not_authorized()
     {
         $user = User::make()->save();
@@ -128,7 +129,7 @@ class DeleteModelTest extends TestCase
         $this->assertFalse($authorize);
     }
 
-    /** @test */
+    #[Test]
     public function it_deletes_models()
     {
         $posts = Post::factory()->count(5)->create();

--- a/tests/Actions/DuplicateModelTest.php
+++ b/tests/Actions/DuplicateModelTest.php
@@ -4,6 +4,7 @@ namespace StatamicRadPack\Runway\Tests\Actions;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -14,7 +15,6 @@ use StatamicRadPack\Runway\Actions\DuplicateModel;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class DuplicateModelTest extends TestCase
 {

--- a/tests/Actions/DuplicateModelTest.php
+++ b/tests/Actions/DuplicateModelTest.php
@@ -14,18 +14,19 @@ use StatamicRadPack\Runway\Actions\DuplicateModel;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class DuplicateModelTest extends TestCase
 {
     use PreventsSavingStacheItemsToDisk;
 
-    /** @test */
+    #[Test]
     public function it_returns_title()
     {
         $this->assertEquals('Duplicate', DuplicateModel::title());
     }
 
-    /** @test */
+    #[Test]
     public function is_visible_to_eloquent_model()
     {
         $visibleTo = (new DuplicateModel())->visibleTo(Post::factory()->create());
@@ -33,7 +34,7 @@ class DuplicateModelTest extends TestCase
         $this->assertTrue($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_eloquent_model_when_resource_is_read_only()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.read_only', true);
@@ -45,7 +46,7 @@ class DuplicateModelTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_eloquent_model_when_blueprint_is_hidden()
     {
         $blueprint = Blueprint::find('runway::post');
@@ -57,7 +58,7 @@ class DuplicateModelTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_eloquent_model_without_a_runway_resource()
     {
         $model = new class extends Model
@@ -70,7 +71,7 @@ class DuplicateModelTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_entry()
     {
         Collection::make('posts')->save();
@@ -82,7 +83,7 @@ class DuplicateModelTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_visible_to_eloquent_models_in_bulk()
     {
         $posts = Post::factory()->count(3)->create();
@@ -92,7 +93,7 @@ class DuplicateModelTest extends TestCase
         $this->assertTrue($visibleToBulk);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_entries_in_bulk()
     {
         Collection::make('posts')->save();
@@ -108,7 +109,7 @@ class DuplicateModelTest extends TestCase
         $this->assertFalse($visibleToBulk);
     }
 
-    /** @test */
+    #[Test]
     public function super_user_is_authorized()
     {
         $user = User::make()->makeSuper()->save();
@@ -118,7 +119,7 @@ class DuplicateModelTest extends TestCase
         $this->assertTrue($authorize);
     }
 
-    /** @test */
+    #[Test]
     public function user_with_permission_is_authorized()
     {
         Role::make('editor')->addPermission('create post')->save();
@@ -132,7 +133,7 @@ class DuplicateModelTest extends TestCase
         Role::find('editor')->delete();
     }
 
-    /** @test */
+    #[Test]
     public function user_without_permission_is_not_authorized()
     {
         $user = User::make()->save();
@@ -142,7 +143,7 @@ class DuplicateModelTest extends TestCase
         $this->assertFalse($authorize);
     }
 
-    /** @test */
+    #[Test]
     public function it_duplicates_models()
     {
         $post = Post::factory()->create(['title' => 'Hello World']);

--- a/tests/Actions/PublishTest.php
+++ b/tests/Actions/PublishTest.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Runway\Tests\Actions;
 
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Role;
@@ -12,7 +13,6 @@ use StatamicRadPack\Runway\Actions\Publish;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class PublishTest extends TestCase
 {

--- a/tests/Actions/PublishTest.php
+++ b/tests/Actions/PublishTest.php
@@ -12,18 +12,19 @@ use StatamicRadPack\Runway\Actions\Publish;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class PublishTest extends TestCase
 {
     use PreventsSavingStacheItemsToDisk;
 
-    /** @test */
+    #[Test]
     public function it_returns_title()
     {
         $this->assertEquals('Publish', Publish::title());
     }
 
-    /** @test */
+    #[Test]
     public function is_visible_to_eloquent_model()
     {
         $visibleTo = (new Publish())->context([])->visibleTo(Post::factory()->unpublished()->create());
@@ -31,7 +32,7 @@ class PublishTest extends TestCase
         $this->assertTrue($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_published_eloquent_model()
     {
         $visibleTo = (new Publish())->context([])->visibleTo(Post::factory()->create());
@@ -39,7 +40,7 @@ class PublishTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_eloquent_model_when_resource_is_read_only()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.read_only', true);
@@ -50,7 +51,7 @@ class PublishTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_entry()
     {
         Collection::make('posts')->save();
@@ -62,7 +63,7 @@ class PublishTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_visible_to_eloquent_models_in_bulk()
     {
         $posts = Post::factory()->count(3)->unpublished()->create();
@@ -72,7 +73,7 @@ class PublishTest extends TestCase
         $this->assertTrue($visibleToBulk);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_in_bulk_to_entry()
     {
         Collection::make('posts')->save();
@@ -84,7 +85,7 @@ class PublishTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_eloquent_models_in_bulk_when_not_all_models_are_unpublished()
     {
         $posts = Post::factory()->count(3)->unpublished()->create();
@@ -95,7 +96,7 @@ class PublishTest extends TestCase
         $this->assertFalse($visibleToBulk);
     }
 
-    /** @test */
+    #[Test]
     public function super_user_is_authorized()
     {
         $user = User::make()->makeSuper()->save();
@@ -105,7 +106,7 @@ class PublishTest extends TestCase
         $this->assertTrue($authorize);
     }
 
-    /** @test */
+    #[Test]
     public function user_with_permission_is_authorized()
     {
         Role::make('editor')->addPermission('edit post')->save();
@@ -119,7 +120,7 @@ class PublishTest extends TestCase
         Role::find('editor')->delete();
     }
 
-    /** @test */
+    #[Test]
     public function user_without_permission_is_not_authorized()
     {
         $user = User::make()->save();
@@ -129,7 +130,7 @@ class PublishTest extends TestCase
         $this->assertFalse($authorize);
     }
 
-    /** @test */
+    #[Test]
     public function it_publishes_models()
     {
         $posts = Post::factory()->count(5)->unpublished()->create();

--- a/tests/Actions/UnpublishTest.php
+++ b/tests/Actions/UnpublishTest.php
@@ -12,18 +12,19 @@ use StatamicRadPack\Runway\Actions\Unpublish;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class UnpublishTest extends TestCase
 {
     use PreventsSavingStacheItemsToDisk;
 
-    /** @test */
+    #[Test]
     public function it_returns_title()
     {
         $this->assertEquals('Unpublish', Unpublish::title());
     }
 
-    /** @test */
+    #[Test]
     public function is_visible_to_eloquent_model()
     {
         $visibleTo = (new Unpublish())->context([])->visibleTo(Post::factory()->create());
@@ -31,7 +32,7 @@ class UnpublishTest extends TestCase
         $this->assertTrue($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_unpublished_eloquent_model()
     {
         $visibleTo = (new Unpublish())->context([])->visibleTo(Post::factory()->unpublished()->create());
@@ -39,7 +40,7 @@ class UnpublishTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_eloquent_model_when_resource_is_read_only()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.read_only', true);
@@ -50,7 +51,7 @@ class UnpublishTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_entry()
     {
         Collection::make('posts')->save();
@@ -62,7 +63,7 @@ class UnpublishTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_in_bulk_to_entry()
     {
         Collection::make('posts')->save();
@@ -74,7 +75,7 @@ class UnpublishTest extends TestCase
         $this->assertFalse($visibleTo);
     }
 
-    /** @test */
+    #[Test]
     public function is_visible_to_eloquent_models_in_bulk()
     {
         $posts = Post::factory()->count(3)->create();
@@ -84,7 +85,7 @@ class UnpublishTest extends TestCase
         $this->assertTrue($visibleToBulk);
     }
 
-    /** @test */
+    #[Test]
     public function is_not_visible_to_eloquent_models_in_bulk_when_not_all_models_are_published()
     {
         $posts = Post::factory()->count(3)->create();
@@ -95,7 +96,7 @@ class UnpublishTest extends TestCase
         $this->assertFalse($visibleToBulk);
     }
 
-    /** @test */
+    #[Test]
     public function super_user_is_authorized()
     {
         $user = User::make()->makeSuper()->save();
@@ -105,7 +106,7 @@ class UnpublishTest extends TestCase
         $this->assertTrue($authorize);
     }
 
-    /** @test */
+    #[Test]
     public function user_with_permission_is_authorized()
     {
         Role::make('editor')->addPermission('edit post')->save();
@@ -119,7 +120,7 @@ class UnpublishTest extends TestCase
         Role::find('editor')->delete();
     }
 
-    /** @test */
+    #[Test]
     public function user_without_permission_is_not_authorized()
     {
         $user = User::make()->save();
@@ -129,7 +130,7 @@ class UnpublishTest extends TestCase
         $this->assertFalse($authorize);
     }
 
-    /** @test */
+    #[Test]
     public function it_publishes_models()
     {
         $posts = Post::factory()->count(5)->create();

--- a/tests/Actions/UnpublishTest.php
+++ b/tests/Actions/UnpublishTest.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Runway\Tests\Actions;
 
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Role;
@@ -12,7 +13,6 @@ use StatamicRadPack\Runway\Actions\Unpublish;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class UnpublishTest extends TestCase
 {

--- a/tests/Console/Commands/GenerateBlueprintTest.php
+++ b/tests/Console/Commands/GenerateBlueprintTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Schema;
 use Statamic\Facades\Blueprint;
 use Statamic\Fields\Blueprint as FieldsBlueprint;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class GenerateBlueprintTest extends TestCase
 {
@@ -22,7 +23,7 @@ class GenerateBlueprintTest extends TestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function can_generate_blueprint()
     {
         Schema::shouldReceive('dropIfExists')->times(7);
@@ -125,7 +126,7 @@ class GenerateBlueprintTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /** @test */
+    #[Test]
     public function can_generate_resource_with_column_that_can_not_be_matched_to_a_fieldtype()
     {
         Schema::shouldReceive('dropIfExists')->times(7);

--- a/tests/Console/Commands/GenerateBlueprintTest.php
+++ b/tests/Console/Commands/GenerateBlueprintTest.php
@@ -5,10 +5,10 @@ namespace StatamicRadPack\Runway\Tests\Console\Commands;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blueprint;
 use Statamic\Fields\Blueprint as FieldsBlueprint;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class GenerateBlueprintTest extends TestCase
 {

--- a/tests/Console/Commands/GenerateMigrationTest.php
+++ b/tests/Console/Commands/GenerateMigrationTest.php
@@ -7,13 +7,13 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\TestTime\TestTime;
 use SplFileInfo;
 use Statamic\Facades\Blueprint;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\TestCase;
 use StatamicRadPack\Runway\Traits\HasRunwayResource;
-use PHPUnit\Framework\Attributes\Test;
 
 class GenerateMigrationTest extends TestCase
 {

--- a/tests/Console/Commands/GenerateMigrationTest.php
+++ b/tests/Console/Commands/GenerateMigrationTest.php
@@ -13,6 +13,7 @@ use Statamic\Facades\Blueprint;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\TestCase;
 use StatamicRadPack\Runway\Traits\HasRunwayResource;
+use PHPUnit\Framework\Attributes\Test;
 
 class GenerateMigrationTest extends TestCase
 {
@@ -45,7 +46,7 @@ class GenerateMigrationTest extends TestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function can_generate_migrations_for_multiple_resources()
     {
         TestTime::freeze();
@@ -95,7 +96,7 @@ class GenerateMigrationTest extends TestCase
         $this->assertFalse(Schema::hasTable('drinks'));
     }
 
-    /** @test */
+    #[Test]
     public function can_generate_migration_for_single_resource()
     {
         TestTime::freeze();
@@ -136,7 +137,7 @@ class GenerateMigrationTest extends TestCase
         $this->assertFalse(Schema::hasTable('foods'));
     }
 
-    /** @test */
+    #[Test]
     public function cant_generate_migration_where_table_already_exists()
     {
         TestTime::freeze();
@@ -170,7 +171,7 @@ class GenerateMigrationTest extends TestCase
         $this->assertFileDoesNotExist(database_path().'/migrations/'.now()->format('Y_m_d_His').'_create_foods_table.php');
     }
 
-    /** @test */
+    #[Test]
     public function can_generate_migration_and_run_them_afterwards()
     {
         TestTime::freeze();
@@ -201,7 +202,7 @@ class GenerateMigrationTest extends TestCase
         $this->assertTrue(Schema::hasTable('foods'));
     }
 
-    /** @test */
+    #[Test]
     public function can_generate_migration_and_ensure_normal_field_is_correct()
     {
         TestTime::freeze();
@@ -245,7 +246,7 @@ class GenerateMigrationTest extends TestCase
         $this->assertFalse(Schema::hasTable('foods'));
     }
 
-    /** @test */
+    #[Test]
     public function can_generate_migration_and_ensure_max_items_1_field_is_correct()
     {
         TestTime::freeze();
@@ -299,7 +300,7 @@ class GenerateMigrationTest extends TestCase
         $this->assertFalse(Schema::hasTable('foods'));
     }
 
-    /** @test */
+    #[Test]
     public function can_generate_migration_and_ensure_field_is_nullable_if_required_not_set()
     {
         TestTime::freeze();
@@ -334,7 +335,7 @@ class GenerateMigrationTest extends TestCase
         $this->assertFalse(Schema::hasTable('foods'));
     }
 
-    /** @test */
+    #[Test]
     public function can_generate_migration_and_ensure_field_is_not_nullable_if_required_set()
     {
         TestTime::freeze();

--- a/tests/Console/Commands/ListResourcesTest.php
+++ b/tests/Console/Commands/ListResourcesTest.php
@@ -3,11 +3,11 @@
 namespace StatamicRadPack\Runway\Tests\Console\Commands;
 
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ListResourcesTest extends TestCase
 {

--- a/tests/Console/Commands/ListResourcesTest.php
+++ b/tests/Console/Commands/ListResourcesTest.php
@@ -7,10 +7,11 @@ use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ListResourcesTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_lists_resources()
     {
         $this
@@ -24,7 +25,7 @@ class ListResourcesTest extends TestCase
             );
     }
 
-    /** @test */
+    #[Test]
     public function it_outputs_error_when_no_resources_exist()
     {
         Config::set('runway.resources', []);

--- a/tests/Console/Commands/RebuildUriCacheTest.php
+++ b/tests/Console/Commands/RebuildUriCacheTest.php
@@ -3,11 +3,11 @@
 namespace StatamicRadPack\Runway\Tests\Console\Commands;
 
 use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\Attributes\Test;
 use StatamicRadPack\Runway\Routing\RunwayUri;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class RebuildUriCacheTest extends TestCase
 {

--- a/tests/Console/Commands/RebuildUriCacheTest.php
+++ b/tests/Console/Commands/RebuildUriCacheTest.php
@@ -7,10 +7,11 @@ use StatamicRadPack\Runway\Routing\RunwayUri;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class RebuildUriCacheTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_rebuilds_the_uri_cache()
     {
         Post::factory()->count(5)->createQuietly();
@@ -25,7 +26,7 @@ class RebuildUriCacheTest extends TestCase
         $this->assertCount(5, RunwayUri::all());
     }
 
-    /** @test */
+    #[Test]
     public function can_build_uri_with_antlers()
     {
         Post::factory()->createQuietly(['slug' => 'hello-world']);
@@ -41,7 +42,7 @@ class RebuildUriCacheTest extends TestCase
         $this->assertEquals('/posts/hello-world', RunwayUri::first()->uri);
     }
 
-    /** @test */
+    #[Test]
     public function does_not_rebuild_uri_cache_when_no_confirmation_is_provided()
     {
         Post::factory()->count(5)->create(); // `create` will trigger the URIs to be built via model events.
@@ -56,7 +57,7 @@ class RebuildUriCacheTest extends TestCase
         $this->assertCount(5, RunwayUri::all());
     }
 
-    /** @test */
+    #[Test]
     public function skips_resources_without_routing_configured()
     {
         Author::factory()->count(3)->createQuietly();

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -7,10 +7,11 @@ use StatamicRadPack\Runway\Data\AugmentedModel;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class AugmentedModelTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_gets_values()
     {
         TestTime::freeze('Y-m-d H:i:s', '2020-01-01 13:46:12');
@@ -43,7 +44,7 @@ class AugmentedModelTest extends TestCase
         $this->assertEquals('John Doe', $augmented->get('author_id')->value()['name']->value());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_nested_values()
     {
         $post = Post::factory()->create([
@@ -61,7 +62,7 @@ class AugmentedModelTest extends TestCase
         $this->assertEquals('<p>This is a <strong>great</strong> post! You should <em>read</em> it.</p>', trim($augmented->get('values')->value()['alt_body']->value()));
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_value_from_model_accessor()
     {
         $post = Post::factory()->create();
@@ -71,7 +72,7 @@ class AugmentedModelTest extends TestCase
         $this->assertEquals('This is an excerpt.', $augmented->get('excerpt')->value());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_value_from_appended_attribute()
     {
         $post = Post::factory()->create();

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -2,12 +2,12 @@
 
 namespace StatamicRadPack\Runway\Tests\Data;
 
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\TestTime\TestTime;
 use StatamicRadPack\Runway\Data\AugmentedModel;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class AugmentedModelTest extends TestCase
 {

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
 use Statamic\Fields\Field;
 use Statamic\Http\Requests\FilteredRequest;
@@ -13,7 +14,6 @@ use StatamicRadPack\Runway\Fieldtypes\BelongsToFieldtype;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class BelongsToFieldtypeTest extends TestCase
 {

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -13,6 +13,7 @@ use StatamicRadPack\Runway\Fieldtypes\BelongsToFieldtype;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class BelongsToFieldtypeTest extends TestCase
 {
@@ -34,7 +35,7 @@ class BelongsToFieldtypeTest extends TestCase
             ]));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items()
     {
         Author::factory()->count(10)->create();
@@ -56,7 +57,7 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItemsWithoutPagination->count(), 10);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_with_title_format()
     {
         $authors = Author::factory()->count(2)->create();
@@ -80,7 +81,7 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->last()['title'], 'AUTHOR '.$authors[1]->name);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_in_order_specified_in_runway_config()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Author.order_by', 'name');
@@ -101,7 +102,7 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->all()[2]['title'], 'Amy Santiago');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_in_order_from_runway_listing_scope()
     {
         Author::factory()->create(['name' => 'Scully']);
@@ -121,7 +122,7 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->all()[2]['title'], 'Amy Santiago');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_in_order_from_runway_listing_scope_when_user_defines_an_order()
     {
         Author::factory()->create(['name' => 'Scully']);
@@ -141,7 +142,7 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->all()[2]['title'], 'Scully');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_and_search()
     {
         Author::factory()->count(10)->create();
@@ -158,7 +159,7 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->first()['id'], $hasselhoff->id);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_and_search_using_a_search_index()
     {
         Config::set('statamic.search.indexes.test_search_index', [
@@ -185,7 +186,7 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->first()['id'], $hasselhoff->id);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_item_array_with_title_format()
     {
         $author = Author::factory()->create();
@@ -204,7 +205,7 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals('AUTHOR '.$author->name, $item->first()['title']);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_pre_process_index()
     {
         $author = Author::factory()->create();
@@ -220,7 +221,7 @@ class BelongsToFieldtypeTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_pre_process_index_with_model_id()
     {
         $author = Author::factory()->create();
@@ -236,7 +237,7 @@ class BelongsToFieldtypeTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_augment_value()
     {
         $author = Author::factory()->create();
@@ -248,13 +249,11 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals($author->name, $augment['name']->value());
     }
 
-    /**
-     * @test
-     *
-     * Under the hood, this tests the `toItemArray` method.
-     */
+    #[Test]
     public function can_get_item_data()
     {
+        // Under the hood, this tests the toItemArray method.
+
         $author = Author::factory()->create();
 
         $getItemData = $this->fieldtype->getItemData($author->id);
@@ -267,7 +266,7 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertArrayNotHasKey('created_at', $getItemData[0]);
     }
 
-    /** @test */
+    #[Test]
     public function gets_graphql_type()
     {
         $toGqlType = $this->fieldtype->toGqlType();

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
 use Statamic\Fields\Field;
 use Statamic\Http\Requests\FilteredRequest;
@@ -14,7 +15,6 @@ use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class HasManyFieldtypeTest extends TestCase
 {

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -14,6 +14,7 @@ use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class HasManyFieldtypeTest extends TestCase
 {
@@ -34,7 +35,7 @@ class HasManyFieldtypeTest extends TestCase
             ]));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items()
     {
         $author = Author::factory()->create();
@@ -57,7 +58,7 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItemsWithoutPagination->count(), 10);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_with_title_format()
     {
         $author = Author::factory()->create();
@@ -81,7 +82,7 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->last()['title'], $posts[1]->title.' TEST '.now()->format('Y'));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_in_order_specified_in_runway_config()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.order_by', 'title');
@@ -104,7 +105,7 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->all()[2]['title'], 'Richard B');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_in_order_from_runway_listing_scope()
     {
         Post::factory()->create(['title' => 'Arnold A']);
@@ -124,7 +125,7 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->all()[2]['title'], 'Richard B');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_in_order_from_runway_listing_scope_when_user_defines_an_order()
     {
         Post::factory()->create(['title' => 'Arnold A']);
@@ -144,7 +145,7 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->all()[2]['title'], 'Arnold A');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_and_search()
     {
         $author = Author::factory()->create();
@@ -164,7 +165,7 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->last()['title'], $spacePandaPosts[2]->title);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_index_items_and_search_using_a_search_index()
     {
         Config::set('statamic.search.indexes.test_search_index', [
@@ -194,7 +195,7 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->last()['title'], $spacePandaPosts[2]->title);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_item_array_with_title_format()
     {
         $author = Author::factory()->create();
@@ -214,7 +215,7 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertEquals($item->last()['title'], $posts[1]->title.' TEST '.now()->format('Y'));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_pre_process_index()
     {
         $author = Author::factory()->create();
@@ -231,7 +232,7 @@ class HasManyFieldtypeTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_augment_value()
     {
         $author = Author::factory()->create();
@@ -248,13 +249,11 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertEquals($posts[0]->title, (string) $augment[0]['title']->value());
     }
 
-    /**
-     * @test
-     *
-     * Under the hood, this tests the `toItemArray` method.
-     */
+    #[Test]
     public function can_get_item_data()
     {
+        // Under the hood, this tests the toItemArray method.
+
         $author = Author::factory()->create();
         $posts = Post::factory()->count(5)->create(['author_id' => $author->id]);
 

--- a/tests/GraphQL/ResourceInterfaceTest.php
+++ b/tests/GraphQL/ResourceInterfaceTest.php
@@ -2,9 +2,9 @@
 
 namespace StatamicRadPack\Runway\Tests\GraphQL;
 
+use PHPUnit\Framework\Attributes\Test;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ResourceInterfaceTest extends TestCase
 {

--- a/tests/GraphQL/ResourceInterfaceTest.php
+++ b/tests/GraphQL/ResourceInterfaceTest.php
@@ -4,10 +4,11 @@ namespace StatamicRadPack\Runway\Tests\GraphQL;
 
 use Rebing\GraphQL\Support\Facades\GraphQL;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ResourceInterfaceTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_adds_types()
     {
         $this->assertEquals([

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -5,6 +5,7 @@ namespace StatamicRadPack\Runway\Tests\Http\Controllers;
 use Statamic\Facades\Config;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ApiControllerTest extends TestCase
 {
@@ -17,7 +18,7 @@ class ApiControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function gets_a_resource_that_exists()
     {
         $posts = Post::factory()->count(2)->create();
@@ -30,7 +31,7 @@ class ApiControllerTest extends TestCase
             ->assertJsonPath('data.1.id', $posts[1]->id);
     }
 
-    /** @test */
+    #[Test]
     public function returns_not_found_on_a_resource_that_doesnt_exist()
     {
         Post::factory()->count(2)->create();
@@ -40,7 +41,7 @@ class ApiControllerTest extends TestCase
             ->assertNotFound();
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_out_unpublished_models()
     {
         $posts = Post::factory()->count(2)->create();
@@ -55,7 +56,7 @@ class ApiControllerTest extends TestCase
             ->assertJsonPath('data.1.id', $posts[1]->id);
     }
 
-    /** @test */
+    #[Test]
     public function paginates_a_resource_list()
     {
         Post::factory()->count(10)->create();
@@ -77,7 +78,7 @@ class ApiControllerTest extends TestCase
             ->assertJsonPath('meta.total', 10);
     }
 
-    /** @test */
+    #[Test]
     public function filters_a_resource_list()
     {
         [$postA, $postB, $postC] = Post::factory()->count(3)->create();
@@ -105,7 +106,7 @@ class ApiControllerTest extends TestCase
             ->assertJsonPath('meta.total', 3);
     }
 
-    /** @test */
+    #[Test]
     public function wont_filter_a_resource_list_on_a_forbidden_filter()
     {
         [$postA, $postB, $postC] = Post::factory()->count(3)->create();
@@ -119,7 +120,7 @@ class ApiControllerTest extends TestCase
             ->assertStatus(422);
     }
 
-    /** @test */
+    #[Test]
     public function gets_a_resource_model_that_exists()
     {
         $post = Post::factory()->create();
@@ -132,7 +133,7 @@ class ApiControllerTest extends TestCase
             ->assertJsonPath('data.title', $post->title);
     }
 
-    /** @test */
+    #[Test]
     public function gets_a_resource_model_with_nested_fields()
     {
         $post = Post::factory()->create([
@@ -152,7 +153,7 @@ class ApiControllerTest extends TestCase
 ');
     }
 
-    /** @test */
+    #[Test]
     public function gets_a_resource_model_with_belongs_to_relationship()
     {
         $post = Post::factory()->create();
@@ -166,7 +167,7 @@ class ApiControllerTest extends TestCase
             ->assertJsonPath('data.author_id.name', $post->author->name);
     }
 
-    /** @test */
+    #[Test]
     public function returns_not_found_on_a_model_that_does_not_exist()
     {
         $this
@@ -174,7 +175,7 @@ class ApiControllerTest extends TestCase
             ->assertNotFound();
     }
 
-    /** @test */
+    #[Test]
     public function it_doesnt_return_unpublished_model()
     {
         $post = Post::factory()->unpublished()->create();

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -2,10 +2,10 @@
 
 namespace StatamicRadPack\Runway\Tests\Http\Controllers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Config;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ApiControllerTest extends TestCase
 {

--- a/tests/Http/Controllers/CP/ModelRevisionsControllerTest.php
+++ b/tests/Http/Controllers/CP/ModelRevisionsControllerTest.php
@@ -7,6 +7,7 @@ use Statamic\Facades\Folder;
 use Statamic\Facades\User;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ModelRevisionsControllerTest extends TestCase
 {
@@ -28,7 +29,7 @@ class ModelRevisionsControllerTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_revisions()
     {
         $this->travelTo('2024-01-01 10:30:00');
@@ -71,7 +72,7 @@ class ModelRevisionsControllerTest extends TestCase
             ->assertJsonPath('1.revisions.1.attributes.item_url', "http://localhost/cp/runway/post/{$model->id}/revisions/".Carbon::parse('2024-01-01 08:00:00')->timestamp);
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_a_revision()
     {
         $model = Post::factory()->unpublished()->create(['title' => 'Original title']);
@@ -109,7 +110,7 @@ class ModelRevisionsControllerTest extends TestCase
         $this->assertTrue($model->hasWorkingCopy());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_revision()
     {
         $model = Post::factory()->create(['title' => 'Original title']);

--- a/tests/Http/Controllers/CP/ModelRevisionsControllerTest.php
+++ b/tests/Http/Controllers/CP/ModelRevisionsControllerTest.php
@@ -3,11 +3,11 @@
 namespace StatamicRadPack\Runway\Tests\Http\Controllers\CP;
 
 use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Folder;
 use Statamic\Facades\User;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ModelRevisionsControllerTest extends TestCase
 {

--- a/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
+++ b/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
@@ -2,11 +2,11 @@
 
 namespace StatamicRadPack\Runway\Tests\Http\Controllers\CP;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Folder;
 use Statamic\Facades\User;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class PublishedModelsControllerTest extends TestCase
 {

--- a/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
+++ b/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
@@ -6,6 +6,7 @@ use Statamic\Facades\Folder;
 use Statamic\Facades\User;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class PublishedModelsControllerTest extends TestCase
 {
@@ -27,7 +28,7 @@ class PublishedModelsControllerTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function can_publish_a_model()
     {
         $model = Post::factory()->unpublished()->create();
@@ -49,7 +50,7 @@ class PublishedModelsControllerTest extends TestCase
         $this->assertTrue($model->fresh()->published());
     }
 
-    /** @test */
+    #[Test]
     public function can_unpublish_a_model()
     {
         $model = Post::factory()->create();

--- a/tests/Http/Controllers/CP/ResourceActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceActionControllerTest.php
@@ -6,6 +6,7 @@ use Statamic\Actions\Action;
 use Statamic\Facades\User;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ResourceActionControllerTest extends TestCase
 {
@@ -16,7 +17,7 @@ class ResourceActionControllerTest extends TestCase
         FooAction::register();
     }
 
-    /** @test */
+    #[Test]
     public function can_run_action()
     {
         $post = Post::factory()->create();
@@ -36,7 +37,7 @@ class ResourceActionControllerTest extends TestCase
         $this->assertTrue(FooAction::$hasRun);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_bulk_actions_list()
     {
         $post = Post::factory()->create();

--- a/tests/Http/Controllers/CP/ResourceActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceActionControllerTest.php
@@ -2,11 +2,11 @@
 
 namespace StatamicRadPack\Runway\Tests\Http\Controllers\CP;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Actions\Action;
 use Statamic\Facades\User;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ResourceActionControllerTest extends TestCase
 {

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Runway\Tests\Http\Controllers\CP;
 
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Config;
 use Statamic\Facades\Role;
@@ -13,7 +14,6 @@ use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\User as UserModel;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ResourceControllerTest extends TestCase
 {

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -13,10 +13,11 @@ use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\User as UserModel;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ResourceControllerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function get_model_index()
     {
         Post::factory()->count(2)->create();
@@ -33,7 +34,7 @@ class ResourceControllerTest extends TestCase
             ]);
     }
 
-    /** @test */
+    #[Test]
     public function can_create_resource()
     {
         $user = User::make()->makeSuper()->save();
@@ -44,7 +45,7 @@ class ResourceControllerTest extends TestCase
             ->assertOk();
     }
 
-    /** @test */
+    #[Test]
     public function cant_create_resource_if_resource_is_read_only()
     {
         Config::set('runway.resources.'.Post::class.'.read_only', true);
@@ -59,7 +60,7 @@ class ResourceControllerTest extends TestCase
             ->assertRedirect();
     }
 
-    /** @test */
+    #[Test]
     public function cant_create_resource_when_blueprint_is_hidden()
     {
         $blueprint = Blueprint::find('runway::post');
@@ -76,7 +77,7 @@ class ResourceControllerTest extends TestCase
             ->assertRedirect();
     }
 
-    /** @test */
+    #[Test]
     public function can_store_resource()
     {
         $author = Author::factory()->create();
@@ -99,7 +100,7 @@ class ResourceControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function cant_store_resource_if_resource_is_read_only()
     {
         Config::set('runway.resources.'.Post::class.'.read_only', true);
@@ -124,7 +125,7 @@ class ResourceControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function cant_store_resource_when_blueprint_is_hidden()
     {
         $postBlueprint = Blueprint::find('runway::post');
@@ -151,10 +152,7 @@ class ResourceControllerTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/pull/223
-     */
+    #[Test]
     public function can_store_resource_and_ensure_computed_field_isnt_saved_to_database()
     {
         $author = Author::factory()->create();
@@ -178,10 +176,7 @@ class ResourceControllerTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/issues/331
-     */
+    #[Test]
     public function can_store_resource_and_ensure_field_isnt_saved_to_database()
     {
         $author = Author::factory()->create();
@@ -205,10 +200,7 @@ class ResourceControllerTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/pull/247
-     */
+    #[Test]
     public function can_store_resource_and_ensure_appended_attribute_doesnt_attempt_to_get_saved()
     {
         $author = Author::factory()->create();
@@ -232,10 +224,7 @@ class ResourceControllerTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/pull/302
-     */
+    #[Test]
     public function can_store_resource_with_nested_field()
     {
         $author = Author::factory()->create();
@@ -259,10 +248,7 @@ class ResourceControllerTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/issues/321
-     */
+    #[Test]
     public function can_store_resource_and_ensure_date_comparison_validation_works()
     {
         $author = Author::factory()->create();
@@ -291,7 +277,7 @@ class ResourceControllerTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function can_edit_resource()
     {
         $post = Post::factory()->create();
@@ -305,7 +291,7 @@ class ResourceControllerTest extends TestCase
             ->assertSee($post->body);
     }
 
-    /** @test */
+    #[Test]
     public function cant_edit_resource_when_it_does_not_exist()
     {
         $user = User::make()->makeSuper()->save();
@@ -317,7 +303,7 @@ class ResourceControllerTest extends TestCase
             ->assertSee('Page Not Found');
     }
 
-    /** @test */
+    #[Test]
     public function can_edit_resource_with_simple_date_field()
     {
         $postBlueprint = Blueprint::find('runway::post');
@@ -356,7 +342,7 @@ class ResourceControllerTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function can_edit_resource_with_date_field_with_default_format()
     {
         $postBlueprint = Blueprint::find('runway::post');
@@ -396,7 +382,7 @@ class ResourceControllerTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function can_edit_resource_with_date_field_with_custom_format()
     {
         $postBlueprint = Blueprint::find('runway::post');
@@ -436,10 +422,7 @@ class ResourceControllerTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/pull/302
-     */
+    #[Test]
     public function can_edit_resource_with_nested_field()
     {
         $post = Post::factory()->create([
@@ -459,7 +442,7 @@ class ResourceControllerTest extends TestCase
             ->assertSee('Im Toby Ziegler, and I work at the White House.');
     }
 
-    /** @test */
+    #[Test]
     public function can_edit_resource_if_resource_is_read_only()
     {
         Config::set('runway.resources.'.Post::class.'.read_only', true);
@@ -477,10 +460,7 @@ class ResourceControllerTest extends TestCase
             ->assertSee($post->body);
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/pull/370
-     */
+    #[Test]
     public function can_edit_resource_with_nested_field_cast_to_object_in_model()
     {
         $post = Post::factory()->create([
@@ -501,7 +481,7 @@ class ResourceControllerTest extends TestCase
             ->assertSee($post->external_links->links[1]->url);
     }
 
-    /** @test */
+    #[Test]
     public function can_edit_resource_if_model_is_user_model()
     {
         Config::set('auth.providers.users.model', UserModel::class);
@@ -527,7 +507,7 @@ class ResourceControllerTest extends TestCase
             ->assertSee('admins');
     }
 
-    /** @test */
+    #[Test]
     public function can_update_resource()
     {
         $post = Post::factory()->create();
@@ -550,7 +530,7 @@ class ResourceControllerTest extends TestCase
         $this->assertEquals($post->title, 'Santa is coming home');
     }
 
-    /** @test */
+    #[Test]
     public function cant_update_resource_if_resource_is_read_only()
     {
         Config::set('runway.resources.'.Post::class.'.read_only', true);
@@ -575,7 +555,7 @@ class ResourceControllerTest extends TestCase
         $this->assertNotSame($post->title, 'Santa is coming home');
     }
 
-    /** @test */
+    #[Test]
     public function can_update_resource_and_ensure_computed_field_isnt_saved_to_database()
     {
         $post = Post::factory()->create();
@@ -599,10 +579,7 @@ class ResourceControllerTest extends TestCase
         $this->assertEquals($post->title, 'Santa is coming home');
     }
 
-    /**
-     *  @test
-     * https://github.com/statamic-rad-pack/runway/issues/331
-     */
+    #[Test]
     public function can_update_resource_and_ensure__field_isnt_saved_to_database()
     {
         $post = Post::factory()->create();
@@ -626,10 +603,7 @@ class ResourceControllerTest extends TestCase
         $this->assertEquals($post->title, 'Santa is coming home');
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/pull/247
-     */
+    #[Test]
     public function can_update_resource_and_ensure_appended_attribute_doesnt_attempt_to_get_saved()
     {
         $post = Post::factory()->create();
@@ -653,10 +627,7 @@ class ResourceControllerTest extends TestCase
         $this->assertEquals($post->title, 'Santa is coming home');
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/pull/302
-     */
+    #[Test]
     public function can_update_resource_with_nested_field()
     {
         $post = Post::factory()->create();
@@ -680,7 +651,7 @@ class ResourceControllerTest extends TestCase
         $this->assertEquals($post->values['alt_title'], 'Claus is venturing out');
     }
 
-    /** @test */
+    #[Test]
     public function can_update_resource_if_model_is_user_model()
     {
         Config::set('auth.providers.users.model', UserModel::class);

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -11,12 +11,13 @@ use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ResourceListingControllerTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 
-    /** @test */
+    #[Test]
     public function user_with_no_permissions_cannot_access_resource_listing()
     {
         $this
@@ -25,7 +26,7 @@ class ResourceListingControllerTest extends TestCase
             ->assertRedirect();
     }
 
-    /** @test */
+    #[Test]
     public function can_sort_listing_rows()
     {
         $user = User::make()->makeSuper()->save();
@@ -51,7 +52,7 @@ class ResourceListingControllerTest extends TestCase
             ]);
     }
 
-    /** @test */
+    #[Test]
     public function listing_rows_are_ordered_as_per_config()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.order_by', 'id');
@@ -82,7 +83,7 @@ class ResourceListingControllerTest extends TestCase
             ]);
     }
 
-    /** @test */
+    #[Test]
     public function listing_rows_are_ordered_from_runway_listing_scope()
     {
         $user = User::make()->makeSuper()->save();
@@ -110,7 +111,7 @@ class ResourceListingControllerTest extends TestCase
             ]);
     }
 
-    /** @test */
+    #[Test]
     public function listing_rows_arent_ordered_from_runway_listing_scope_when_user_defines_an_order()
     {
         $user = User::make()->makeSuper()->save();
@@ -138,7 +139,7 @@ class ResourceListingControllerTest extends TestCase
             ]);
     }
 
-    /** @test */
+    #[Test]
     public function listing_rows_are_ordered_when_user_defines_an_order_and_no_runway_listing_scope_order_exists()
     {
         $user = User::make()->makeSuper()->save();
@@ -164,7 +165,7 @@ class ResourceListingControllerTest extends TestCase
             ]);
     }
 
-    /** @test */
+    #[Test]
     public function can_search()
     {
         $user = User::make()->makeSuper()->save();
@@ -187,7 +188,7 @@ class ResourceListingControllerTest extends TestCase
             ]);
     }
 
-    /** @test */
+    #[Test]
     public function can_search_models_with_has_many_relationship()
     {
         $user = User::make()->makeSuper()->save();
@@ -212,7 +213,7 @@ class ResourceListingControllerTest extends TestCase
             ]);
     }
 
-    /** @test */
+    #[Test]
     public function can_search_using_a_search_index()
     {
         Config::set('statamic.search.indexes.test_search_index', [
@@ -245,7 +246,7 @@ class ResourceListingControllerTest extends TestCase
             ]);
     }
 
-    /** @test */
+    #[Test]
     public function can_paginate_results()
     {
         Post::factory()->count(15)->create();
@@ -264,10 +265,7 @@ class ResourceListingControllerTest extends TestCase
             ]);
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/pull/223
-     */
+    #[Test]
     public function can_get_values_from_nested_fields()
     {
         $posts = Post::factory()->count(3)->create([

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -5,13 +5,13 @@ namespace StatamicRadPack\Runway\Tests\Http\Controllers\CP;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
 use Statamic\Facades\User;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ResourceListingControllerTest extends TestCase
 {

--- a/tests/Http/Controllers/CP/RestoreModelRevisionController.php
+++ b/tests/Http/Controllers/CP/RestoreModelRevisionController.php
@@ -2,11 +2,11 @@
 
 namespace StatamicRadPack\Runway\Tests\Http\Controllers\CP;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Folder;
 use Statamic\Facades\User;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class RestoreModelRevisionController extends TestCase
 {

--- a/tests/Http/Controllers/CP/RestoreModelRevisionController.php
+++ b/tests/Http/Controllers/CP/RestoreModelRevisionController.php
@@ -6,6 +6,7 @@ use Statamic\Facades\Folder;
 use Statamic\Facades\User;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class RestoreModelRevisionController extends TestCase
 {
@@ -27,7 +28,7 @@ class RestoreModelRevisionController extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_restores_revision()
     {
         $model = Post::factory()->create(['title' => 'Some new title']);

--- a/tests/Policies/ResourcePolicyTest.php
+++ b/tests/Policies/ResourcePolicyTest.php
@@ -2,12 +2,12 @@
 
 namespace StatamicRadPack\Runway\Tests\Policies;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Role;
 use Statamic\Facades\User;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ResourcePolicyTest extends TestCase
 {

--- a/tests/Policies/ResourcePolicyTest.php
+++ b/tests/Policies/ResourcePolicyTest.php
@@ -7,10 +7,11 @@ use Statamic\Facades\User;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ResourcePolicyTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function can_view_resource()
     {
         $resource = Runway::findResource('post');
@@ -21,7 +22,7 @@ class ResourcePolicyTest extends TestCase
         $this->assertTrue($user->can('view', $resource));
     }
 
-    /** @test */
+    #[Test]
     public function can_view_resource_with_model()
     {
         $resource = Runway::findResource('post');
@@ -32,7 +33,7 @@ class ResourcePolicyTest extends TestCase
         $this->assertTrue($user->can('view', [$resource, new Post]));
     }
 
-    /** @test */
+    #[Test]
     public function can_create_resource()
     {
         $resource = Runway::findResource('post');
@@ -53,7 +54,7 @@ class ResourcePolicyTest extends TestCase
         $this->assertTrue($user->can('edit', $resource));
     }
 
-    /** @test */
+    #[Test]
     public function can_edit_resource_with_model()
     {
         $resource = Runway::findResource('post');
@@ -74,7 +75,7 @@ class ResourcePolicyTest extends TestCase
         $this->assertTrue($user->can('delete', $resource));
     }
 
-    /** @test */
+    #[Test]
     public function can_delete_resource_with_model()
     {
         $resource = Runway::findResource('post');

--- a/tests/Query/Scopes/Filters/ModelsTest.php
+++ b/tests/Query/Scopes/Filters/ModelsTest.php
@@ -8,10 +8,11 @@ use StatamicRadPack\Runway\Query\Scopes\Filters\Fields\Models;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ModelsTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_gets_field_items()
     {
         $fieldtype = new BelongsToFieldtype;
@@ -31,7 +32,7 @@ class ModelsTest extends TestCase
         ], $fieldItems['field']['options']);
     }
 
-    /** @test */
+    #[Test]
     public function can_apply_filter_on_normal_column()
     {
         Post::factory()->count(5)->create();
@@ -60,7 +61,7 @@ class ModelsTest extends TestCase
         $this->assertEquals($author->id, $results[2]->author_id);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_badge()
     {
         $fieldtype = new BelongsToFieldtype;

--- a/tests/Query/Scopes/Filters/ModelsTest.php
+++ b/tests/Query/Scopes/Filters/ModelsTest.php
@@ -2,13 +2,13 @@
 
 namespace StatamicRadPack\Runway\Tests\Query\Scopes\Filters;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Fields\Field;
 use StatamicRadPack\Runway\Fieldtypes\BelongsToFieldtype;
 use StatamicRadPack\Runway\Query\Scopes\Filters\Fields\Models;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ModelsTest extends TestCase
 {

--- a/tests/RelationshipsTest.php
+++ b/tests/RelationshipsTest.php
@@ -2,12 +2,12 @@
 
 namespace StatamicRadPack\Runway\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blueprint;
 use Statamic\Fields\Blueprint as FieldsBlueprint;
 use StatamicRadPack\Runway\Relationships;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
-use PHPUnit\Framework\Attributes\Test;
 
 class RelationshipsTest extends TestCase
 {

--- a/tests/RelationshipsTest.php
+++ b/tests/RelationshipsTest.php
@@ -7,10 +7,11 @@ use Statamic\Fields\Blueprint as FieldsBlueprint;
 use StatamicRadPack\Runway\Relationships;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
+use PHPUnit\Framework\Attributes\Test;
 
 class RelationshipsTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function can_add_models_when_saving_has_many_relationship()
     {
         $author = Author::factory()->create();
@@ -37,7 +38,7 @@ class RelationshipsTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function can_delete_models_when_saving_has_many_relationship()
     {
         $author = Author::factory()->create();
@@ -67,7 +68,7 @@ class RelationshipsTest extends TestCase
         $this->assertDatabaseHas('posts', ['id' => $posts[2]->id, 'author_id' => $author->id]);
     }
 
-    /** @test */
+    #[Test]
     public function can_update_sort_orders_when_saving_has_many_relationship()
     {
         $author = Author::factory()->create();
@@ -98,7 +99,7 @@ class RelationshipsTest extends TestCase
         $this->assertDatabaseHas('posts', ['id' => $posts[2]->id, 'author_id' => $author->id, 'sort_order' => 1]);
     }
 
-    /** @test */
+    #[Test]
     public function can_add_models_when_saving_belongs_to_many_relationship()
     {
         $author = Author::factory()->create();
@@ -123,7 +124,7 @@ class RelationshipsTest extends TestCase
         $this->assertDatabaseHas('post_author', ['post_id' => $posts[2]->id, 'author_id' => $author->id]);
     }
 
-    /** @test */
+    #[Test]
     public function can_remove_models_when_saving_belongs_to_many_relationship()
     {
         $author = Author::factory()->create();
@@ -151,7 +152,7 @@ class RelationshipsTest extends TestCase
         $this->assertDatabaseHas('post_author', ['post_id' => $posts[2]->id, 'author_id' => $author->id]);
     }
 
-    /** @test */
+    #[Test]
     public function can_update_sort_orders_when_saving_belongs_to_relationship()
     {
         $author = Author::factory()->create();

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -3,10 +3,10 @@
 namespace StatamicRadPack\Runway\Tests;
 
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Fieldset;
 use StatamicRadPack\Runway\Runway;
-use PHPUnit\Framework\Attributes\Test;
 
 class ResourceTest extends TestCase
 {

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -6,10 +6,11 @@ use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Fieldset;
 use StatamicRadPack\Runway\Runway;
+use PHPUnit\Framework\Attributes\Test;
 
 class ResourceTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function can_get_eloquent_relationships_for_belongs_to_field()
     {
         Runway::discoverResources();
@@ -21,7 +22,7 @@ class ResourceTest extends TestCase
         $this->assertContains('author', $eloquentRelationships->toArray());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_eloquent_relationships_for_has_many_field()
     {
         $blueprint = Blueprint::find('runway::author');
@@ -42,7 +43,7 @@ class ResourceTest extends TestCase
         $this->assertContains('posts', $eloquentRelationships->toArray());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_eloquent_relationships_for_runway_uri_routing()
     {
         Runway::discoverResources();
@@ -54,7 +55,7 @@ class ResourceTest extends TestCase
         $this->assertContains('runwayUri', $eloquentRelationships->toArray());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_eager_loading_relationships()
     {
         Runway::discoverResources();
@@ -69,7 +70,7 @@ class ResourceTest extends TestCase
         ], $eagerLoadingRelationships);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_eager_loading_relationships_from_config()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.with', [
@@ -87,7 +88,7 @@ class ResourceTest extends TestCase
         ], $eagerLoadingRelationships);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_generated_singular()
     {
         Runway::discoverResources();
@@ -99,7 +100,7 @@ class ResourceTest extends TestCase
         $this->assertEquals($singular, 'Post');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_configured_singular()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.singular', 'Bibliothek');
@@ -113,7 +114,7 @@ class ResourceTest extends TestCase
         $this->assertEquals($singular, 'Bibliothek');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_generated_plural()
     {
         Runway::discoverResources();
@@ -125,7 +126,7 @@ class ResourceTest extends TestCase
         $this->assertEquals($plural, 'Posts');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_configured_plural()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.plural', 'Bibliotheken');
@@ -139,7 +140,7 @@ class ResourceTest extends TestCase
         $this->assertEquals($plural, 'Bibliotheken');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_blueprint()
     {
         $resource = Runway::findResource('post');
@@ -151,7 +152,7 @@ class ResourceTest extends TestCase
         $this->assertSame('post', $blueprint->handle());
     }
 
-    /** @test */
+    #[Test]
     public function can_create_blueprint_if_one_does_not_exist()
     {
         $resource = Runway::findResource('post');
@@ -168,7 +169,7 @@ class ResourceTest extends TestCase
         $this->assertSame('post', $blueprint->handle());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_listable_columns()
     {
         Fieldset::make('seo')->setContents([
@@ -209,7 +210,7 @@ class ResourceTest extends TestCase
         ], $resource->listableColumns()->toArray());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_title_field()
     {
         $blueprint = Blueprint::make()->setContents([
@@ -237,7 +238,7 @@ class ResourceTest extends TestCase
         $this->assertEquals('values->listable_hidden_field', $resource->titleField());
     }
 
-    /** @test */
+    #[Test]
     public function revisions_can_be_enabled()
     {
         Config::set('statamic.editions.pro', true);
@@ -253,7 +254,7 @@ class ResourceTest extends TestCase
         $this->assertTrue($resource->revisionsEnabled());
     }
 
-    /** @test */
+    #[Test]
     public function revisions_cant_be_enabled_without_revisions_being_enabled_globally()
     {
         Config::set('statamic.editions.pro', true);
@@ -269,7 +270,7 @@ class ResourceTest extends TestCase
         $this->assertFalse($resource->revisionsEnabled());
     }
 
-    /** @test */
+    #[Test]
     public function revisions_cant_be_enabled_without_statamic_pro()
     {
         Config::set('statamic.editions.pro', false);
@@ -285,7 +286,7 @@ class ResourceTest extends TestCase
         $this->assertFalse($resource->revisionsEnabled());
     }
 
-    /** @test */
+    #[Test]
     public function revisions_cant_be_enabled_without_publish_states()
     {
         Config::set('statamic.editions.pro', true);

--- a/tests/Routing/FrontendRoutingTest.php
+++ b/tests/Routing/FrontendRoutingTest.php
@@ -6,10 +6,11 @@ use Illuminate\Support\Facades\Config;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class FrontendRoutingTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function returns_resource_response_for_resource()
     {
         $post = Post::factory()->create();
@@ -23,10 +24,7 @@ class FrontendRoutingTest extends TestCase
             ->assertSee('LAYOUT: layout');
     }
 
-    /**
-     * @test
-     * https://github.com/statamic-rad-pack/runway/pull/302
-     */
+    #[Test]
     public function returns_resource_response_for_resource_with_nested_field()
     {
         $post = Post::factory()->create([
@@ -45,7 +43,7 @@ class FrontendRoutingTest extends TestCase
             ->assertSee('LAYOUT: layout');
     }
 
-    /** @test */
+    #[Test]
     public function returns_resource_response_for_resource_with_custom_template()
     {
         Config::set('runway.resources.'.Post::class.'.template', 'custom');
@@ -63,7 +61,7 @@ class FrontendRoutingTest extends TestCase
             ->assertSee('LAYOUT: layout');
     }
 
-    /** @test */
+    #[Test]
     public function returns_resource_response_for_resource_with_custom_layout()
     {
         Config::set('runway.resources.'.Post::class.'.layout', 'blog-layout');

--- a/tests/Routing/FrontendRoutingTest.php
+++ b/tests/Routing/FrontendRoutingTest.php
@@ -3,10 +3,10 @@
 namespace StatamicRadPack\Runway\Tests\Routing;
 
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class FrontendRoutingTest extends TestCase
 {

--- a/tests/Routing/ResourceRoutingRepositoryTest.php
+++ b/tests/Routing/ResourceRoutingRepositoryTest.php
@@ -2,11 +2,11 @@
 
 namespace StatamicRadPack\Runway\Tests\Routing;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Data;
 use StatamicRadPack\Runway\Routing\RoutingModel;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ResourceRoutingRepositoryTest extends TestCase
 {

--- a/tests/Routing/ResourceRoutingRepositoryTest.php
+++ b/tests/Routing/ResourceRoutingRepositoryTest.php
@@ -6,10 +6,11 @@ use Statamic\Facades\Data;
 use StatamicRadPack\Runway\Routing\RoutingModel;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ResourceRoutingRepositoryTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function can_find_by_uri()
     {
         $post = Post::factory()->create();
@@ -23,7 +24,7 @@ class ResourceRoutingRepositoryTest extends TestCase
         $this->assertTrue($findByUri instanceof RoutingModel);
     }
 
-    /** @test */
+    #[Test]
     public function can_find_by_uri_where_multiple_matches_are_found()
     {
         $posts = Post::factory()->count(5)->create(['slug' => 'chicken-fried-rice']);
@@ -34,7 +35,7 @@ class ResourceRoutingRepositoryTest extends TestCase
         $this->assertTrue($findByUri instanceof RoutingModel);
     }
 
-    /** @test */
+    #[Test]
     public function cant_find_by_uri_if_no_matching_uri()
     {
         $findByUri = Data::findByUri('/posts/some-absolute-jibber-jabber');
@@ -42,7 +43,7 @@ class ResourceRoutingRepositoryTest extends TestCase
         $this->assertNull($findByUri);
     }
 
-    /** @test */
+    #[Test]
     public function cant_find_by_uri_if_a_similar_uri_exists()
     {
         $post = Post::factory()->create();
@@ -55,7 +56,7 @@ class ResourceRoutingRepositoryTest extends TestCase
         $this->assertNull($findByUri);
     }
 
-    /** @test */
+    #[Test]
     public function cant_find_by_uri_when_model_is_unpublished()
     {
         $post = Post::factory()->unpublished()->create();

--- a/tests/Routing/RoutingModelTest.php
+++ b/tests/Routing/RoutingModelTest.php
@@ -9,10 +9,11 @@ use StatamicRadPack\Runway\Routing\RoutingModel;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class RoutingModelTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function can_get_route()
     {
         $post = Post::factory()->createQuietly();
@@ -23,7 +24,7 @@ class RoutingModelTest extends TestCase
         $this->assertEquals('/blog/post-slug', $routingModel->route());
     }
 
-    /** @test */
+    #[Test]
     public function cant_get_route_without_runway_uri()
     {
         $post = Post::factory()->createQuietly();
@@ -33,7 +34,7 @@ class RoutingModelTest extends TestCase
         $this->assertNull($routingModel->route());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_route_data()
     {
         $post = Post::factory()->createQuietly();
@@ -46,7 +47,7 @@ class RoutingModelTest extends TestCase
         ], $routingModel->routeData());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_uri()
     {
         $post = Post::factory()->createQuietly();
@@ -57,7 +58,7 @@ class RoutingModelTest extends TestCase
         $this->assertEquals('/blog/post-slug', $routingModel->uri());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_url_without_redirect()
     {
         $post = Post::factory()->createQuietly();
@@ -68,7 +69,7 @@ class RoutingModelTest extends TestCase
         $this->assertEquals('/blog/post-slug', $routingModel->urlWithoutRedirect());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_response()
     {
         $post = Post::factory()->createQuietly();
@@ -83,7 +84,7 @@ class RoutingModelTest extends TestCase
         $this->assertStringContainsString("<article>{$post->body}</article>", $response->getContent());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_template()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.template', 'posts.show');
@@ -97,7 +98,7 @@ class RoutingModelTest extends TestCase
         $this->assertEquals('posts.show', $routingModel->template());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_layout()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.layout', 'layouts.post');
@@ -111,7 +112,7 @@ class RoutingModelTest extends TestCase
         $this->assertEquals('layouts.post', $routingModel->layout());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_id()
     {
         $post = Post::factory()->createQuietly();
@@ -122,7 +123,7 @@ class RoutingModelTest extends TestCase
         $this->assertEquals($post->id, $routingModel->id());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_route_key()
     {
         $post = Post::factory()->createQuietly();
@@ -133,7 +134,7 @@ class RoutingModelTest extends TestCase
         $this->assertEquals($post->id, $routingModel->getRouteKey());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_augmented_array_data()
     {
         $post = Post::factory()->createQuietly();
@@ -144,7 +145,7 @@ class RoutingModelTest extends TestCase
         $this->assertEquals($post->toArray(), $routingModel->augmentedArrayData());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_something_from_model()
     {
         $post = Post::factory()->createQuietly();

--- a/tests/Routing/RoutingModelTest.php
+++ b/tests/Routing/RoutingModelTest.php
@@ -5,11 +5,11 @@ namespace StatamicRadPack\Runway\Tests\Routing;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use StatamicRadPack\Runway\Routing\RoutingModel;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class RoutingModelTest extends TestCase
 {

--- a/tests/RunwayTest.php
+++ b/tests/RunwayTest.php
@@ -7,10 +7,11 @@ use Illuminate\Support\Collection;
 use Statamic\Fields\Blueprint;
 use StatamicRadPack\Runway\Resource;
 use StatamicRadPack\Runway\Runway;
+use PHPUnit\Framework\Attributes\Test;
 
 class RunwayTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function can_discover_and_get_all_resources()
     {
         Runway::discoverResources();
@@ -36,7 +37,7 @@ class RunwayTest extends TestCase
         $this->assertTrue($all[2]->blueprint() instanceof Blueprint);
     }
 
-    /** @test */
+    #[Test]
     public function can_find_resource()
     {
         Runway::discoverResources();

--- a/tests/RunwayTest.php
+++ b/tests/RunwayTest.php
@@ -4,10 +4,10 @@ namespace StatamicRadPack\Runway\Tests;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Fields\Blueprint;
 use StatamicRadPack\Runway\Resource;
 use StatamicRadPack\Runway\Runway;
-use PHPUnit\Framework\Attributes\Test;
 
 class RunwayTest extends TestCase
 {

--- a/tests/Search/ProviderTest.php
+++ b/tests/Search/ProviderTest.php
@@ -2,11 +2,11 @@
 
 namespace StatamicRadPack\Runway\Tests\Search;
 
+use PHPUnit\Framework\Attributes\Test;
 use StatamicRadPack\Runway\Search\Provider;
 use StatamicRadPack\Runway\Search\Searchable;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class ProviderTest extends TestCase
 {

--- a/tests/Search/ProviderTest.php
+++ b/tests/Search/ProviderTest.php
@@ -6,10 +6,11 @@ use StatamicRadPack\Runway\Search\Provider;
 use StatamicRadPack\Runway\Search\Searchable;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ProviderTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_gets_models()
     {
         $posts = Post::factory()->count(5)->create();
@@ -30,7 +31,7 @@ class ProviderTest extends TestCase
         $this->assertEquals("runway::post::{$posts[4]->id}", $models[4]->getSearchReference());
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_out_unpublished_models()
     {
         $publishedModels = Post::factory()->count(2)->create();

--- a/tests/Search/SearchableTest.php
+++ b/tests/Search/SearchableTest.php
@@ -7,10 +7,11 @@ use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Search\Searchable;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class SearchableTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function can_get_resource()
     {
         $post = Post::factory()->create();
@@ -20,7 +21,7 @@ class SearchableTest extends TestCase
         $this->assertEquals(Runway::findResource('post'), $searchable->resource());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_queryable_value()
     {
         $post = Post::factory()->create();
@@ -33,7 +34,7 @@ class SearchableTest extends TestCase
         $this->assertEquals('default', $searchable->getQueryableValue('site'));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_search_value()
     {
         $post = Post::factory()->create();
@@ -45,7 +46,7 @@ class SearchableTest extends TestCase
         $this->assertEquals($post->id, $searchable->getSearchValue('id'));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_search_reference()
     {
         $post = Post::factory()->create();
@@ -55,7 +56,7 @@ class SearchableTest extends TestCase
         $this->assertEquals("runway::post::{$post->id}", $searchable->getSearchReference());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_search_result()
     {
         $post = Post::factory()->create();
@@ -69,7 +70,7 @@ class SearchableTest extends TestCase
         $this->assertEquals('runway:post', $result->getType());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_cp_search_result_title()
     {
         $post = Post::factory()->create();
@@ -79,7 +80,7 @@ class SearchableTest extends TestCase
         $this->assertEquals($post->title, $searchable->getCpSearchResultTitle());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_cp_search_result_url()
     {
         $post = Post::factory()->create();
@@ -89,7 +90,7 @@ class SearchableTest extends TestCase
         $this->assertStringContainsString("/runway/post/{$post->id}", $searchable->getCpSearchResultUrl());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_cp_search_result_badge()
     {
         $post = Post::factory()->create();
@@ -99,7 +100,7 @@ class SearchableTest extends TestCase
         $this->assertEquals('Posts', $searchable->getCpSearchResultBadge());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_new_augmented_instance()
     {
         $post = Post::factory()->create();

--- a/tests/Search/SearchableTest.php
+++ b/tests/Search/SearchableTest.php
@@ -2,12 +2,12 @@
 
 namespace StatamicRadPack\Runway\Tests\Search;
 
+use PHPUnit\Framework\Attributes\Test;
 use StatamicRadPack\Runway\Data\AugmentedModel;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Search\Searchable;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class SearchableTest extends TestCase
 {

--- a/tests/Support/JsonTest.php
+++ b/tests/Support/JsonTest.php
@@ -2,9 +2,9 @@
 
 namespace StatamicRadPack\Runway\Tests\Support;
 
+use PHPUnit\Framework\Attributes\Test;
 use StatamicRadPack\Runway\Support\Json;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class JsonTest extends TestCase
 {

--- a/tests/Support/JsonTest.php
+++ b/tests/Support/JsonTest.php
@@ -4,10 +4,11 @@ namespace StatamicRadPack\Runway\Tests\Support;
 
 use StatamicRadPack\Runway\Support\Json;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class JsonTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_determines_if_array_is_json()
     {
         $isJson = Json::isJson([
@@ -17,7 +18,7 @@ class JsonTest extends TestCase
         $this->assertFalse($isJson);
     }
 
-    /** @test */
+    #[Test]
     public function it_determines_if_object_is_json()
     {
         $isJson = Json::isJson((object) [
@@ -27,7 +28,7 @@ class JsonTest extends TestCase
         $this->assertFalse($isJson);
     }
 
-    /** @test */
+    #[Test]
     public function it_determines_if_json_string_is_json()
     {
         $isJson = Json::isJson(json_encode([

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Runway\Tests\Tags;
 
 use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Blueprint;
 use Statamic\Fields\Value;
@@ -11,7 +12,6 @@ use StatamicRadPack\Runway\Tags\RunwayTag;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class RunwayTagTest extends TestCase
 {

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -11,6 +11,7 @@ use StatamicRadPack\Runway\Tags\RunwayTag;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class RunwayTagTest extends TestCase
 {
@@ -25,13 +26,13 @@ class RunwayTagTest extends TestCase
             ->setContext([]);
     }
 
-    /** @test */
+    #[Test]
     public function has_been_registered()
     {
         $this->assertTrue(isset(app()['statamic.tags']['runway']));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_no_parameters()
     {
         $posts = Post::factory()->count(5)->create();
@@ -48,7 +49,7 @@ class RunwayTagTest extends TestCase
         $this->assertEquals((string) $usage[4]['title'], $posts[4]->title);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_select_parameter()
     {
         $posts = Post::factory()->count(5)->create();
@@ -82,7 +83,7 @@ class RunwayTagTest extends TestCase
         $this->assertEmpty((string) $usage[4]['body']->value());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_scope_parameter()
     {
         $posts = Post::factory()->count(5)->create();
@@ -103,7 +104,7 @@ class RunwayTagTest extends TestCase
         $this->assertEquals((string) $usage[2]['title']->value(), 'Burger');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_scope_parameter_and_scope_arguments()
     {
         $posts = Post::factory()->count(5)->create();
@@ -126,7 +127,7 @@ class RunwayTagTest extends TestCase
         $this->assertEquals((string) $usage[0]['title']->value(), 'Apple');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_scope_parameter_and_scope_arguments_and_multiple_scopes()
     {
         $posts = Post::factory()->count(5)->create();
@@ -149,7 +150,7 @@ class RunwayTagTest extends TestCase
         $this->assertEquals((string) $usage[0]['title']->value(), 'Apple');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_where_parameter()
     {
         $posts = Post::factory()->count(5)->create();
@@ -166,7 +167,7 @@ class RunwayTagTest extends TestCase
         $this->assertEquals((string) $usage[0]['title']->value(), 'penguin');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_where_parameter_when_condition_is_on_relationship_field()
     {
         $posts = Post::factory()->count(5)->create();
@@ -188,7 +189,7 @@ class RunwayTagTest extends TestCase
         $this->assertEquals((string) $usage[2]['title']->value(), $posts[3]->title);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_with_parameter()
     {
         $posts = Post::factory()->count(5)->create();
@@ -208,7 +209,7 @@ class RunwayTagTest extends TestCase
         $this->assertEquals($usage[0]['author']->value()['name']->value(), $posts[0]->author->name);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_sort_parameter()
     {
         $posts = Post::factory()->count(2)->create();
@@ -228,7 +229,7 @@ class RunwayTagTest extends TestCase
         $this->assertEquals((string) $usage[1]['title'], 'abc');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_scoping()
     {
         $posts = Post::factory()->count(2)->create();
@@ -248,7 +249,7 @@ class RunwayTagTest extends TestCase
         $this->assertEquals((string) $usage['items'][1]['title'], 'def');
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_limit_parameter()
     {
         $posts = Post::factory()->count(5)->create();
@@ -267,7 +268,7 @@ class RunwayTagTest extends TestCase
         $this->assertFalse(isset($usage[2]));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_scoping_and_pagination()
     {
         $posts = Post::factory()->count(5)->create();
@@ -290,7 +291,7 @@ class RunwayTagTest extends TestCase
         $this->assertArrayHasKey('no_results', $usage);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_and_non_blueprint_columns_are_returned()
     {
         $posts = Post::factory()->count(2)->create();
@@ -308,7 +309,7 @@ class RunwayTagTest extends TestCase
         $this->assertEquals((string) $usage[1]['title']->value(), $posts[1]['title']);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_models_with_studly_case_resource_handle()
     {
         $postBlueprint = Blueprint::find('runway::post');

--- a/tests/UpdateScripts/ChangePermissionNamesTest.php
+++ b/tests/UpdateScripts/ChangePermissionNamesTest.php
@@ -5,12 +5,13 @@ namespace StatamicRadPack\Runway\Tests\UpdateScripts;
 use Illuminate\Support\Facades\File;
 use StatamicRadPack\Runway\Tests\TestCase;
 use StatamicRadPack\Runway\UpdateScripts\ChangePermissionNames;
+use PHPUnit\Framework\Attributes\Test;
 
 class ChangePermissionNamesTest extends TestCase
 {
     use RunsUpdateScripts;
 
-    /** @test */
+    #[Test]
     public function it_can_change_permission_names()
     {
         File::ensureDirectoryExists(resource_path('users'));

--- a/tests/UpdateScripts/ChangePermissionNamesTest.php
+++ b/tests/UpdateScripts/ChangePermissionNamesTest.php
@@ -3,9 +3,9 @@
 namespace StatamicRadPack\Runway\Tests\UpdateScripts;
 
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use StatamicRadPack\Runway\Tests\TestCase;
 use StatamicRadPack\Runway\UpdateScripts\ChangePermissionNames;
-use PHPUnit\Framework\Attributes\Test;
 
 class ChangePermissionNamesTest extends TestCase
 {


### PR DESCRIPTION
This pull request migrates over to PHPUnit attributes in the test suite, as metadata is being deprecated and will be removed in the next version.