### PR TITLE
[7.x] Add augmentation hook

### DIFF
--- a/src/Data/HasAugmentedInstance.php
+++ b/src/Data/HasAugmentedInstance.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Runway\Data;
 
 use Statamic\Contracts\Data\Augmented;
+use Statamic\Support\Traits\Hookable;
 
 /**
  * This trait is a copy of HasAugmentedInstance built into Statamic BUT
@@ -10,6 +11,8 @@ use Statamic\Contracts\Data\Augmented;
  */
 trait HasAugmentedInstance
 {
+    use Hookable;
+
     public function augmentedValue($key)
     {
         return $this->augmented()->get($key);
@@ -39,7 +42,7 @@ trait HasAugmentedInstance
 
     public function augmented()
     {
-        return $this->newAugmentedInstance();
+        return $this->runHooks('augmented', $this->newAugmentedInstance());
     }
 
     abstract public function newAugmentedInstance(): Augmented;

--- a/src/Ignition/Solutions/AddTraitToModel.php
+++ b/src/Ignition/Solutions/AddTraitToModel.php
@@ -9,9 +9,7 @@ use StatamicRadPack\Runway\Traits\HasRunwayResource;
 
 class AddTraitToModel implements RunnableSolution
 {
-    public function __construct(protected $model = null)
-    {
-    }
+    public function __construct(protected $model = null) {}
 
     public function getSolutionTitle(): string
     {

--- a/src/Relationships.php
+++ b/src/Relationships.php
@@ -10,9 +10,7 @@ use StatamicRadPack\Runway\Fieldtypes\HasManyFieldtype;
 
 class Relationships
 {
-    public function __construct(protected Model $model, protected array $values = [])
-    {
-    }
+    public function __construct(protected Model $model, protected array $values = []) {}
 
     public static function for(Model $model): self
     {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -22,8 +22,7 @@ class Resource
         protected Model $model,
         protected string $name,
         protected Collection $config
-    ) {
-    }
+    ) {}
 
     public function handle(): string
     {

--- a/src/Routing/ResourceResponse.php
+++ b/src/Routing/ResourceResponse.php
@@ -14,9 +14,7 @@ class ResourceResponse implements Responsable
 
     protected $with = [];
 
-    public function __construct(protected $data)
-    {
-    }
+    public function __construct(protected $data) {}
 
     public function toResponse($request)
     {

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -354,7 +354,7 @@ class RunwayTagTest extends TestCase
         });
 
         $this->tag->setParameters([]);
-        $usage = $this->tag->wildcard('blog_posts');
+        $this->tag->wildcard('blog_posts');
 
         $this->assertEquals(1, $augmentedCount);
     }


### PR DESCRIPTION
This PR adds an `augmented` hook to Runway resources, similar to the functionality in core: https://github.com/statamic/cms/pull/9625

My use case is this will let us track Runway resources in our Cache Tracker add-on.