### PR TITLE
[7.x] Fixed error when accessing Runway's fieldtypes via GraphQL

### DIFF
--- a/src/Fieldtypes/BelongsToFieldtype.php
+++ b/src/Fieldtypes/BelongsToFieldtype.php
@@ -42,7 +42,7 @@ class BelongsToFieldtype extends BaseFieldtype
 
         return [
             'type' => GraphQL::type("runway_graphql_types_{$resource->handle()}"),
-            'resolve' => function ($item, $args, $context, ResolveInfo $info) use ($resource) {
+            'resolve' => function ($item, $args, $context, ResolveInfo $info) {
                 if (! $item instanceof Model) {
                     return $item->get($info->fieldName);
                 }

--- a/src/Fieldtypes/BelongsToFieldtype.php
+++ b/src/Fieldtypes/BelongsToFieldtype.php
@@ -47,7 +47,7 @@ class BelongsToFieldtype extends BaseFieldtype
                     return $item->get($info->fieldName);
                 }
 
-                return $item->getAttribute($info->fieldName);
+                return $item->{$info->fieldName};
             },
         ];
     }

--- a/src/Fieldtypes/BelongsToFieldtype.php
+++ b/src/Fieldtypes/BelongsToFieldtype.php
@@ -2,6 +2,8 @@
 
 namespace StatamicRadPack\Runway\Fieldtypes;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Database\Eloquent\Model;
 use Statamic\Facades\GraphQL;
 use StatamicRadPack\Runway\Runway;
 
@@ -38,6 +40,15 @@ class BelongsToFieldtype extends BaseFieldtype
     {
         $resource = Runway::findResource($this->config('resource'));
 
-        return GraphQL::type("runway_graphql_types_{$resource->handle()}");
+        return [
+            'type' => GraphQL::type("runway_graphql_types_{$resource->handle()}"),
+            'resolve' => function ($item, $args, $context, ResolveInfo $info) use ($resource) {
+                if (! $item instanceof Model) {
+                    return $item->get($info->fieldName);
+                }
+
+                return $item->getAttribute($info->fieldName);
+            },
+        ];
     }
 }

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -77,7 +77,13 @@ class HasManyFieldtype extends BaseFieldtype
 
         return [
             'type' => GraphQL::listOf(GraphQL::type("runway_graphql_types_{$resource->handle()}")),
-            'resolve' => fn ($model, $args, $context, ResolveInfo $info) => $model->{$info->fieldName},
+            'resolve' => function ($item, $args, $context, ResolveInfo $info) {
+                if (! $item instanceof Model) {
+                    return $item->get($info->fieldName);
+                }
+
+                return $item->getAttribute($info->fieldName);
+            },
         ];
     }
 }

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -82,7 +82,7 @@ class HasManyFieldtype extends BaseFieldtype
                     return $item->get($info->fieldName);
                 }
 
-                return $item->getAttribute($info->fieldName);
+                return $item->{$info->fieldName};
             },
         ];
     }

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -265,12 +265,4 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertArrayHasKey('title', $getItemData[0]);
         $this->assertArrayNotHasKey('created_at', $getItemData[0]);
     }
-
-    #[Test]
-    public function gets_graphql_type()
-    {
-        $toGqlType = $this->fieldtype->toGqlType();
-
-        $this->assertInstanceOf(\GraphQL\Type\Definition\ObjectType::class, $toGqlType);
-    }
 }


### PR DESCRIPTION
This pull request fixes an issue with GraphQL and Runway's Belongs To & Has Many fieldtypes, when the fields are added to an entry blueprint. 

Fixes #561.