### PR TITLE
[7.x] Fix explicit relationship name being overwritten in HasMany relationships

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -176,6 +176,14 @@ class Resource
             ->mapWithKeys(function (Field $field) {
                 $eloquentRelationship = $field->handle();
 
+                // If the field has a `relationship_name` config key, use that instead.
+                // Sometimes a column name will be different to the relationship name
+                // (the method on the model) so our magic won't be able to figure out what's what.
+                // Eg. standard_parent_id -> parent
+                if ($field->get('relationship_name')) {
+                    return [$field->handle() => $field->get('relationship_name')];
+                }
+
                 // If field handle is `author_id`, strip off the `_id`
                 if (str_contains($eloquentRelationship, '_id')) {
                     $eloquentRelationship = Str::replaceLast('_id', '', $eloquentRelationship);
@@ -184,14 +192,6 @@ class Resource
                 // If field handle contains an underscore, convert the name to camel case
                 if (str_contains($eloquentRelationship, '_')) {
                     $eloquentRelationship = Str::camel($eloquentRelationship);
-                }
-
-                // If the field has a `relationship_name` config key, use that instead.
-                // Sometimes a column name will be different to the relationship name
-                // (the method on the model) so our magic won't be able to figure out what's what.
-                // Eg. standard_parent_id -> parent
-                if ($field->get('relationship_name')) {
-                    $eloquentRelationship = $field->get('relationship_name');
                 }
 
                 return [$field->handle() => $eloquentRelationship];

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -176,14 +176,6 @@ class Resource
             ->mapWithKeys(function (Field $field) {
                 $eloquentRelationship = $field->handle();
 
-                // If the field has a `relationship_name` config key, use that instead.
-                // Sometimes a column name will be different to the relationship name
-                // (the method on the model) so our magic won't be able to figure out what's what.
-                // Eg. standard_parent_id -> parent
-                if ($field->get('relationship_name')) {
-                    $eloquentRelationship = $field->get('relationship_name');
-                }
-
                 // If field handle is `author_id`, strip off the `_id`
                 if (str_contains($eloquentRelationship, '_id')) {
                     $eloquentRelationship = Str::replaceLast('_id', '', $eloquentRelationship);
@@ -192,6 +184,14 @@ class Resource
                 // If field handle contains an underscore, convert the name to camel case
                 if (str_contains($eloquentRelationship, '_')) {
                     $eloquentRelationship = Str::camel($eloquentRelationship);
+                }
+
+                // If the field has a `relationship_name` config key, use that instead.
+                // Sometimes a column name will be different to the relationship name
+                // (the method on the model) so our magic won't be able to figure out what's what.
+                // Eg. standard_parent_id -> parent
+                if ($field->get('relationship_name')) {
+                    $eloquentRelationship = $field->get('relationship_name');
                 }
 
                 return [$field->handle() => $eloquentRelationship];


### PR DESCRIPTION
Hi there! My problem was the following:

My relationship method names are - rather old fashioned - named in snake case, f.e. "voucher_themes()". As your package tries to guess the right method name, it automatically converts this to "voucherThemes()". 

You have an explicit attribute that can be used for this ("relationship_name") - but in your method the part where this was implemented was followed by the one where it looks for a snake case name and converts it, so the "relationship_name" one is immediately overwritten.

I moved the part where it uses the "relationship_name" to the end of the logic, so if this is used, it will not be overwritten by other logic following it. 

This fixes my problem - but if you like I can dig a bit deeper and rewrite the method so that it checks if the snake_case method exists? That way we would not have to explicitly fill the "relationship_name" even though it is the same as the field handle (this feels a little awkward).

Cheers, Sebastian