### PR TITLE
[7.x] Prevent saving computed relationship fields

### DIFF
--- a/src/Relationships.php
+++ b/src/Relationships.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Statamic\Fields\Field;
-use Statamic\Fieldtypes\Section;
 use StatamicRadPack\Runway\Fieldtypes\HasManyFieldtype;
 
 class Relationships

--- a/src/Relationships.php
+++ b/src/Relationships.php
@@ -29,7 +29,7 @@ class Relationships
     public function save(): void
     {
         $this->model->runwayResource()->blueprint()->fields()->all()
-            ->filter(fn (Field $field) => $this->shouldSaveField($field))
+            ->reject(fn (Field $field) => $field->visibility() === 'computed' || ! $field->get('save', true))
             ->filter(fn (Field $field) => $field->fieldtype() instanceof HasManyFieldtype)
             ->each(function (Field $field): void {
                 $relationshipName = $this->model->runwayResource()->eloquentRelationships()->get($field->handle());
@@ -74,22 +74,5 @@ class Relationships
         }
 
         $relationship->sync($values);
-    }
-
-    protected function shouldSaveField(Field $field): bool
-    {
-        if ($field->fieldtype() instanceof Section) {
-            return false;
-        }
-
-        if ($field->visibility() === 'computed') {
-            return false;
-        }
-
-        if ($field->get('save', true) === false) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/tests/RelationshipsTest.php
+++ b/tests/RelationshipsTest.php
@@ -180,4 +180,31 @@ class RelationshipsTest extends TestCase
         $this->assertDatabaseHas('post_author', ['post_id' => $posts[1]->id, 'author_id' => $author->id, 'pivot_sort_order' => 2]);
         $this->assertDatabaseHas('post_author', ['post_id' => $posts[2]->id, 'author_id' => $author->id, 'pivot_sort_order' => 1]);
     }
+
+    #[Test]
+    public function does_not_attempt_to_save_computed_fields()
+    {
+        $author = Author::factory()->create();
+        $posts = Post::factory()->count(10)->create();
+
+        Blueprint::shouldReceive('find')->with('runway::post')->andReturn(new FieldsBlueprint);
+
+        Blueprint::shouldReceive('find')
+            ->with('runway::author')
+            ->andReturn((new FieldsBlueprint)->setContents([
+                'tabs' => [
+                    'main' => [
+                        'fields' => [
+                            ['handle' => 'posts', 'field' => ['type' => 'has_many', 'mode' => 'stack', 'resource' => 'post', 'visibility' => 'computed', 'save' => false]],
+                        ],
+                    ],
+                ],
+            ]));
+
+        Relationships::for($author)->with(['posts' => $posts->pluck('id')->all()])->save();
+
+        $this->assertFalse(
+            $posts->every(fn ($post) => $post->fresh()->author_id === $author->id)
+        );
+    }
 }


### PR DESCRIPTION
This pull request prevents relationship fields set as computed or `save: false` from attempting to save to the model.

Related comment: https://github.com/statamic-rad-pack/runway/issues/572#issuecomment-2253114305