### PR TITLE
[7.x] Fix protected model accessors & model mutators without accessor equivelent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "laravel/prompts": "^0.1.17",
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/ignition": "^1.15",
+        "spatie/invade": "^2.1",
         "statamic/cms": "^5.7.0"
     },
     "require-dev": {

--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -180,9 +180,13 @@ class AugmentedModel extends AbstractAugmented
             function () use ($handle) {
                 $method = Str::camel($handle);
 
-                $get = $this->data->$method()->get;
+                $attribute = invade($this->data)->$method();
 
-                return $get();
+                if (! $attribute->get) {
+                    return $this->data->getAttribute($handle);
+                }
+
+                return ($attribute->get)();
             },
             $handle,
             $this->fieldtype($handle),


### PR DESCRIPTION
This pull request fixes an issue where `protected` model accessors would cause an error (Laravel documents them as `protected`). 

This PR also prevents an error when a mutator exists on a model without an accessor equivelent.

Fixes #573.