### PR TITLE
[7.x] Fix JSON field revisions

### DIFF
--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -185,10 +185,15 @@ trait HasRunwayResource
             ->reject(fn (Field $field) => $field->visibility() === 'computed')
             ->reject(fn (Field $field) => $field->get('save', true) === false)
             ->mapWithKeys(function (Field $field) {
+                $isJsonField = Str::contains($field->handle(), '->');
                 $handle = Str::before($field->handle(), '->');
 
                 if ($field->fieldtype() instanceof HasManyFieldtype) {
                     return [$handle => Arr::get($this->runwayRelationships, $handle, [])];
+                }
+
+                if ($isJsonField) {
+                    return [$handle => $this->getAttribute($handle)];
                 }
 
                 return [$handle => $this->getAttribute($field->handle())];

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -184,19 +184,15 @@ trait HasRunwayResource
             ->reject(fn (Field $field) => $field->fieldtype() instanceof Section)
             ->reject(fn (Field $field) => $field->visibility() === 'computed')
             ->reject(fn (Field $field) => $field->get('save', true) === false)
+            ->unique(fn (Field $field) => Str::before($field->handle(), '->'))
             ->mapWithKeys(function (Field $field) {
-                $isJsonField = Str::contains($field->handle(), '->');
                 $handle = Str::before($field->handle(), '->');
 
                 if ($field->fieldtype() instanceof HasManyFieldtype) {
                     return [$handle => Arr::get($this->runwayRelationships, $handle, [])];
                 }
 
-                if ($isJsonField) {
-                    return [$handle => $this->getAttribute($handle)];
-                }
-
-                return [$handle => $this->getAttribute($field->handle())];
+                return [$handle => $this->getAttribute($handle)];
             })
             ->all();
 


### PR DESCRIPTION
Due to https://github.com/statamic-rad-pack/runway/pull/556, model fields that are json data are removed from the working copy because `$this->getAttribute($field->handle())` returns `null` when the handle is `foo->bar`.

Instead we need to get `foo`.

No tests yet @duncanmcclean but this code does work.