### PR TITLE
[7.x] Don't consider non-text fields eligible for a resource's "title field" 

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -130,12 +130,10 @@ class Resource
         }
 
         return $this->listableColumns()
-            ->reject(function ($handle) {
+            ->filter(function ($handle) {
                 $field = $this->blueprint()->field($handle);
 
-                return $field->fieldtype()->indexComponent() === 'relationship'
-                    || $field->type() === 'section'
-                    || $field->handle() === 'published';
+                return in_array($field->type(), ['text', 'textarea', 'slug']);
             })
             ->first();
     }


### PR DESCRIPTION
This pull request fixes an issue where Runway would consider non-text fields, like Asset fields or Entry fields as eligible to be "title fields".

Fixes  #578.