### PR TITLE
[7.x] Only create the blueprints when not running on console

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -195,9 +195,10 @@ class ServiceProvider extends AddonServiceProvider
         try {
             Blueprint::addNamespace('runway', base_path('resources/blueprints/runway'));
 
-            if (! app()->runningInConsole() ) {
-                Runway::allResources()->each(fn(Resource $resource) => $resource->blueprint());
+            if (! app()->runningInConsole()) {
+                Runway::allResources()->each(fn (Resource $resource) => $resource->blueprint());
             }
+
         } catch (QueryException $e) {
             // A QueryException will be thrown when using the Eloquent Driver, where the `blueprints` table is
             // yet to be migrated (for example: during a fresh install). We'll catch the exception here and

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -195,7 +195,9 @@ class ServiceProvider extends AddonServiceProvider
         try {
             Blueprint::addNamespace('runway', base_path('resources/blueprints/runway'));
 
-            Runway::allResources()->each(fn (Resource $resource) => $resource->blueprint());
+            if (! app()->runningInConsole() ) {
+                Runway::allResources()->each(fn(Resource $resource) => $resource->blueprint());
+            }
         } catch (QueryException $e) {
             // A QueryException will be thrown when using the Eloquent Driver, where the `blueprints` table is
             // yet to be migrated (for example: during a fresh install). We'll catch the exception here and

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -198,7 +198,6 @@ class ServiceProvider extends AddonServiceProvider
             if (! app()->runningInConsole()) {
                 Runway::allResources()->each(fn (Resource $resource) => $resource->blueprint());
             }
-
         } catch (QueryException $e) {
             // A QueryException will be thrown when using the Eloquent Driver, where the `blueprints` table is
             // yet to be migrated (for example: during a fresh install). We'll catch the exception here and


### PR DESCRIPTION
We have [our own package](https://github.com/rapidez/statamic) that uses the runway add-on. We have defined [default Runway resources](https://github.com/rapidez/statamic/blob/master/config/rapidez/statamic.php#L56) in this module. As we're updating our module to be compatible with the latest version of Runway we've come across a problem.

We want to define the blueprints in our module, thus we had the config file. In the latest Runway version, blueprints live in `.yaml` files under the `resources/blueprints/vendor/runway` directory. We'd like to use the `php artisan vendor:publish` command to copy our module defined blueprints to the project. Sadly when running `php artisan vendor:publish` the [Runway service provider](https://github.com/statamic-rad-pack/runway/blob/7.x/src/ServiceProvider.php#L198) is registered first and creates empty blueprints. This causes the default blueprints to be already present, and thus can't ours be published.

Our blueprint in the module:
`brand.yaml`
```yaml
tabs:
  main:
    sections:
      -
        fields:
          -
            handle: option_id
            field:
              type: integer
          -
            handle: sort_order
            field:
              type: integer
          -
            handle: value_admin
            field:
              type: text
          -
            handle: value_store
            field:
              type: text
```

Blueprint after publishing (no error occured):
```yaml
tabs:
  main:
    sections:
      -
        fields: {}
```


Let me know if you need any more information.