### PR TITLE
[7.x] Add runway:count tag

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -129,6 +129,20 @@ As [with the collection tag](https://statamic.dev/tags/collection#scope), you ma
 {{ /runway:post }}
 ```
 
+## Count Tag
+
+When you just want to know how many results you have, you can use the `{{ runway:count }}` tag.
+
+```antlers
+{{ runway:count from="posts" }}
+```
+
+You can use the `where` parameter to filter the results:
+
+```antlers
+{{ runway:count from="posts" where="author_name:duncan" }}
+```
+
 ## Publish State
 
 By default, when you're using Runway's [Publish States](/resources#publish-states) feature, only published models are included. Models can be queried against `published` or `draft` status with conditions on `status` like this:

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Tags;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
@@ -14,9 +15,37 @@ use StatamicRadPack\Runway\Runway;
 class RunwayTag extends Tags
 {
     protected static $handle = 'runway';
+    protected $resource;
 
-    public function wildcard($resourceHandle = null): array
+    protected function parseResource(?string $resourceHandle = null): Resource
     {
+        $from = $resourceHandle ?? $this->params->get(['from', 'in', 'resource']);
+
+        if ($resource = Runway::findResource(Str::studly($from))) {
+            return $resource;
+        }
+
+        if ($resource = Runway::findResource(Str::lower($from))) {
+            return $resource;
+        }
+
+        return Runway::findResource($from);
+    }
+
+    public function wildcard(?string $resourceHandle = null): array
+    {
+        $this->resource = $this->parseResource($resourceHandle);
+
+        return $this->results($this->query());
+    }
+
+    public function count(): int
+    {
+        $resourceHandle = $this->params->get('in');
+        if (! $resourceHandle) {
+            return 0;
+        }
+
         try {
             $resource = Runway::findResource(
                 $this->params->has('resource') ? Str::studly($this->params->get('resource')) : Str::studly($resourceHandle)
@@ -27,7 +56,12 @@ class RunwayTag extends Tags
             );
         }
 
-        $query = $resource->model()->query()
+        return $resource->model()->query()->count();
+    }
+
+    protected function query(): Builder
+    {
+        $query = $this->resource->model()->query()
             ->when(
                 $this->params->get('status'),
                 fn ($query, $status) => $query->whereStatus($status),
@@ -36,7 +70,7 @@ class RunwayTag extends Tags
             ->when(
                 $this->params->get('with'),
                 fn ($query) => $query->with(explode('|', (string) $this->params->get('with'))),
-                fn ($query) => $query->with($resource->eagerLoadingRelationships())
+                fn ($query) => $query->with($this->resource->eagerLoadingRelationships())
             );
 
         if ($select = $this->params->get('select')) {
@@ -70,12 +104,12 @@ class RunwayTag extends Tags
             $key = explode(':', (string) $where)[0];
             $value = explode(':', (string) $where)[1];
 
-            if ($resource->eloquentRelationships()->has($key)) {
+            if ($this->resource->eloquentRelationships()->has($key)) {
                 // eloquentRelationships() returns a Collection of keys/values, the keys are the field names
                 // & the values are the Eloquent relationship names. We need to get the relationship name
                 // for the whereHas query.
-                $relationshipName = $resource->eloquentRelationships()->get($key);
-                $relationshipResource = Runway::findResource($resource->blueprint()->field($key)->config()['resource']);
+                $relationshipName = $this->resource->eloquentRelationships()->get($key);
+                $relationshipResource = Runway::findResource($this->resource->blueprint()->field($key)->config()['resource']);
 
                 $query->whereHas($relationshipName, function ($query) use ($value, $relationshipResource) {
                     $query->whereIn($relationshipResource->databaseTable().'.'.$relationshipResource->primaryKey(), Arr::wrap($value));
@@ -96,7 +130,10 @@ class RunwayTag extends Tags
 
             $query->orderBy($sortColumn, $sortDirection);
         }
+    }
 
+    protected function results($query)
+    {
         if ($this->params->get('paginate') || $this->params->get('limit')) {
             $paginator = $query->paginate($this->params->get('limit'));
 
@@ -114,41 +151,21 @@ class RunwayTag extends Tags
         }
 
         if (! $this->params->has('as')) {
-            return $this->augmentModels($results, $resource);
+            return $this->augmentModels($results);
         }
 
         return [
-            $this->params->get('as') => $this->augmentModels($results, $resource),
+            $this->params->get('as') => $this->augmentModels($results),
             'paginate' => isset($paginator) ? $this->getPaginationData($paginator) : null,
             'no_results' => collect($results)->isEmpty(),
         ];
     }
 
-    public function count(): int
-    {
-        $resourceHandle = $this->params->get('in');
-        if (! $resourceHandle) {
-            return 0;
-        }
-
-        try {
-            $resource = Runway::findResource(
-                $this->params->has('resource') ? Str::studly($this->params->get('resource')) : Str::studly($resourceHandle)
-            );
-        } catch (ResourceNotFound) {
-            $resource = Runway::findResource(
-                $this->params->has('resource') ? Str::lower($this->params->get('resource')) : Str::lower($resourceHandle)
-            );
-        }
-
-        return $resource->model()->query()->count();
-    }
-
-    protected function augmentModels($query, Resource $resource): array
+    protected function augmentModels($query): array
     {
         return collect($query)
-            ->map(function ($model, $key) use ($resource) {
-                return Blink::once("Runway::Tag::AugmentModels::{$resource->handle()}::{$model->{$resource->primaryKey()}}", function () use ($model) {
+            ->map(function ($model, $key) {
+                return Blink::once("Runway::Tag::AugmentModels::{$this->resource->handle()}::{$model->{$this->resource->primaryKey()}}", function () use ($model) {
                     return $model->toAugmentedArray();
                 });
             })

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -41,22 +41,9 @@ class RunwayTag extends Tags
 
     public function count(): int
     {
-        $resourceHandle = $this->params->get('in');
-        if (! $resourceHandle) {
-            return 0;
-        }
+        $this->resource = $this->parseResource();
 
-        try {
-            $resource = Runway::findResource(
-                $this->params->has('resource') ? Str::studly($this->params->get('resource')) : Str::studly($resourceHandle)
-            );
-        } catch (ResourceNotFound) {
-            $resource = Runway::findResource(
-                $this->params->has('resource') ? Str::lower($this->params->get('resource')) : Str::lower($resourceHandle)
-            );
-        }
-
-        return $resource->model()->query()->count();
+        return $this->query()->count();
     }
 
     protected function query(): Builder

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -21,15 +21,15 @@ class RunwayTag extends Tags
     {
         $from = $resourceHandle ?? $this->params->get(['from', 'in', 'resource']);
 
-        if ($resource = Runway::findResource(Str::studly($from))) {
-            return $resource;
+        try {
+            return Runway::findResource(Str::studly($from));
+        } catch (ResourceNotFound) {
+            try {
+                return Runway::findResource(Str::lower($from));
+            } catch (ResourceNotFound) {
+                return Runway::findResource($from);
+            }
         }
-
-        if ($resource = Runway::findResource(Str::lower($from))) {
-            return $resource;
-        }
-
-        return Runway::findResource($from);
     }
 
     public function wildcard(?string $resourceHandle = null): array
@@ -117,6 +117,8 @@ class RunwayTag extends Tags
 
             $query->orderBy($sortColumn, $sortDirection);
         }
+
+        return $query;
     }
 
     protected function results($query)

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -124,6 +124,26 @@ class RunwayTag extends Tags
         ];
     }
 
+    public function count(): int
+    {
+        $resourceHandle = $this->params->get('in');
+        if (! $resourceHandle) {
+            return 0;
+        }
+
+        try {
+            $resource = Runway::findResource(
+                $this->params->has('resource') ? Str::studly($this->params->get('resource')) : Str::studly($resourceHandle)
+            );
+        } catch (ResourceNotFound) {
+            $resource = Runway::findResource(
+                $this->params->has('resource') ? Str::lower($this->params->get('resource')) : Str::lower($resourceHandle)
+            );
+        }
+
+        return $resource->model()->query()->count();
+    }
+
     protected function augmentModels($query, Resource $resource): array
     {
         return collect($query)

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -358,4 +358,20 @@ class RunwayTagTest extends TestCase
 
         $this->assertEquals(1, $augmentedCount);
     }
+
+    #[Test]
+    public function it_can_count_models()
+    {
+        Post::factory()->count(3)->create();
+        Post::factory()->count(2)->create(['title' => 'Foo Bar']);
+
+        $count = $this->tag
+            ->setParameters([
+                'from' => 'post',
+                'where' => 'title:Foo Bar',
+            ])
+            ->count();
+
+        $this->assertEquals(2, $count);
+    }
 }


### PR DESCRIPTION
I couldn't find it anywhere in the docs or code. If it already exists or there's another way to quickly count all resources feel free to close. Inspired by the collection:count [tag](https://statamic.dev/tags/collection-count).

```php
Statamic::tag('runway:count')->in('plant')
// or
{{ runway:count in="plant" }}
```