### PR TITLE
[7.x] Add missing `page` variable for Blade templates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,7 @@
     "authors": [
         {
             "name": "Duncan McClean",
-            "email": "duncan@doublethree.digital",
-            "homepage": "https://duncanmcclean.com",
-            "role": "Developer"
+            "email": "duncan@statamic.com"
         }
     ],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/ignition": "^1.15",
         "spatie/invade": "^2.1",
-        "statamic/cms": "^5.7.0"
+        "statamic/cms": "^5.25.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/src/Routing/ResourceResponse.php
+++ b/src/Routing/ResourceResponse.php
@@ -54,7 +54,7 @@ class ResourceResponse implements Responsable
         $contents = (new View)
             ->template($this->data->template())
             ->layout($this->data->layout())
-            ->with($this->data->toAugmentedArray())
+            ->cascadeContent($this->data)
             ->render();
 
         return $contents;


### PR DESCRIPTION
This pull request fixes an issue where the `page` variable was missing in Blade templates, due to Statamic only adding it when we pass the model as the view's `cascadeContents`.

Fixes #584.
Related: statamic/cms#10759.