### PR TITLE
[7.x] Fix sorting in listing tables

### DIFF
--- a/resources/js/components/resources/View.vue
+++ b/resources/js/components/resources/View.vue
@@ -16,8 +16,6 @@
 
         <runway-listing
             :resource="handle"
-            :initial-sort-column="sortColumn"
-            :initial-sort-direction="sortDirection"
             :initial-columns="columns"
             :filters="filters"
             :action-url="actionUrl"
@@ -44,8 +42,6 @@ export default {
         canCreate: { type: Boolean, required: true },
         createUrl: { type: String, required: true },
         createLabel: { type: String, required: true },
-        sortColumn: { type: String, required: true },
-        sortDirection: { type: String, required: true },
         columns: { type: Array, required: true },
         filters: { type: Array, required: true },
         actionUrl: { type: String, required: true },

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -10,8 +10,6 @@
         :can-create="{{ Statamic\Support\Str::bool($canCreate) }}"
         create-url="{{ $createUrl }}"
         create-label="{{ $createLabel }}"
-        sort-column="{{ $resource->orderBy() }}"
-        sort-direction="{{ $resource->orderByDirection() }}"
         :columns="{{ $columns->toJson() }}"
         :filters="{{ $filters->toJson() }}"
         action-url="{{ $actionUrl }}"


### PR DESCRIPTION
This pull request fixes an issue with the Listing Table where it wouldn't use the order defined in a custom `runwayListing` query scope.

Fixes #587.