### PR TITLE
[7.x] Refactor the fieldtype model selector 

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -265,33 +265,18 @@ class BaseFieldtype extends Relationship
     protected function getColumns()
     {
         $resource = Runway::findResource($this->config('resource'));
-        $blueprint = $resource->blueprint();
 
-        return $resource->listableColumns()
-            ->map(function ($columnKey, $index) use ($blueprint) {
-                /** @var \Statamic\Fields\Field $field */
-                $blueprintField = $blueprint->field($columnKey);
-
-                return Column::make()
-                    ->field($blueprintField->handle())
-                    ->label(__($blueprintField->display()))
-                    ->fieldtype($blueprintField->fieldtype()->indexComponent())
-                    ->listable($blueprintField->isListable())
-                    ->defaultVisibility($blueprintField->isVisibleOnListing())
-                    ->visible($blueprintField->isVisibleOnListing())
-                    ->sortable($blueprintField->isSortable())
-                    ->defaultOrder($index + 1);
-            })
+        return $resource->blueprint()->columns()
             ->when($resource->hasPublishStates(), function ($collection) {
-                $collection->push(
-                    Column::make('status')
-                        ->listable(true)
-                        ->visible(true)
-                        ->defaultVisibility(true)
-                        ->sortable(false)
-                );
+                $collection->put('status', Column::make('status')
+                    ->listable(true)
+                    ->visible(true)
+                    ->defaultVisibility(true)
+                    ->sortable(false));
             })
-            ->toArray();
+            ->setPreferred("runway.{$resource->handle()}.columns")
+            ->rejectUnlisted()
+            ->values();
     }
 
     protected function toItemArray($id)

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -128,6 +128,10 @@ class BaseFieldtype extends Relationship
 
         $results = ($paginate = $request->boolean('paginate', true)) ? $query->paginate() : $query->get();
 
+        if ($searchQuery && $resource->hasSearchIndex()) {
+            $results->setCollection($results->getCollection()->map(fn ($item) => $item->getSearchable()->model()));
+        }
+
         $items = $results->map(fn ($item) => $item instanceof Result ? $item->getSearchable() : $item);
 
         return $paginate ? $results->setCollection($items) : $items;

--- a/src/Http/Resources/CP/FieldtypeListedModel.php
+++ b/src/Http/Resources/CP/FieldtypeListedModel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace StatamicRadPack\Runway\Http\Resources\CP;
+
+use StatamicRadPack\Runway\Fieldtypes\BaseFieldtype;
+
+class FieldtypeListedModel extends ListedModel
+{
+    private BaseFieldtype $fieldtype;
+
+    public function fieldtype(BaseFieldtype $fieldtype): self
+    {
+        $this->fieldtype = $fieldtype;
+
+        return $this;
+    }
+}

--- a/src/Http/Resources/CP/FieldtypeModel.php
+++ b/src/Http/Resources/CP/FieldtypeModel.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace StatamicRadPack\Runway\Http\Resources\CP;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Statamic\Facades\Parse;
+use StatamicRadPack\Runway\Fieldtypes\BaseFieldtype;
+
+class FieldtypeModel extends JsonResource
+{
+    private BaseFieldtype $fieldtype;
+
+    public function __construct($resource, BaseFieldtype $fieldtype)
+    {
+        $this->fieldtype = $fieldtype;
+
+        parent::__construct($resource);
+    }
+
+    public function toArray($request)
+    {
+        $data = [
+            'id' => $this->resource->getKey(),
+            'reference' => $this->resource->reference(),
+            'title' => $this->makeTitle($this->resource),
+            'status' => $this->resource->publishedStatus(),
+            'edit_url' => $this->resource->runwayEditUrl(),
+        ];
+
+        return ['data' => $data];
+    }
+
+    protected function makeTitle($model): ?string
+    {
+        if (! $titleFormat = $this->fieldtype->config('title_format')) {
+            $firstListableColumn = $this->resource->runwayResource()->titleField();
+
+            return $model->getAttribute($firstListableColumn);
+        }
+
+        return Parse::template($titleFormat, $model);
+    }
+}

--- a/src/Http/Resources/CP/FieldtypeModels.php
+++ b/src/Http/Resources/CP/FieldtypeModels.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace StatamicRadPack\Runway\Http\Resources\CP;
+
+use Illuminate\Pagination\AbstractPaginator;
+use StatamicRadPack\Runway\Fieldtypes\BaseFieldtype;
+
+class FieldtypeModels extends Models
+{
+    private BaseFieldtype $fieldtype;
+    public $collects = FieldtypeListedModel::class;
+
+    public function __construct($resource, BaseFieldtype $fieldtype)
+    {
+        $this->fieldtype = $fieldtype;
+
+        parent::__construct($resource);
+    }
+
+    protected function collectResource($resource)
+    {
+        $collection = parent::collectResource($resource);
+
+        if ($collection instanceof AbstractPaginator) {
+            $collection->getCollection()->each->fieldtype($this->fieldtype);
+        } else {
+            $collection->each->fieldtype($this->fieldtype);
+        }
+
+        return $collection;
+    }
+}

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -58,30 +58,6 @@ class BelongsToFieldtypeTest extends TestCase
     }
 
     #[Test]
-    public function can_get_index_items_with_title_format()
-    {
-        $authors = Author::factory()->count(2)->create();
-
-        $this->fieldtype->setField(new Field('author', [
-            'max_items' => 1,
-            'mode' => 'default',
-            'resource' => 'author',
-            'display' => 'Author',
-            'type' => 'belongs_to',
-            'title_format' => 'AUTHOR {{ name }}',
-        ]));
-
-        $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest);
-
-        $this->assertIsObject($getIndexItems);
-        $this->assertTrue($getIndexItems instanceof Paginator);
-        $this->assertEquals($getIndexItems->count(), 2);
-
-        $this->assertEquals($getIndexItems->first()['title'], 'AUTHOR '.$authors[0]->name);
-        $this->assertEquals($getIndexItems->last()['title'], 'AUTHOR '.$authors[1]->name);
-    }
-
-    #[Test]
     public function can_get_index_items_in_order_specified_in_runway_config()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Author.order_by', 'name');
@@ -97,9 +73,9 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertTrue($getIndexItems instanceof Collection);
         $this->assertEquals($getIndexItems->count(), 3);
 
-        $this->assertEquals($getIndexItems->all()[0]['title'], 'Scully');
-        $this->assertEquals($getIndexItems->all()[1]['title'], 'Jake Peralta');
-        $this->assertEquals($getIndexItems->all()[2]['title'], 'Amy Santiago');
+        $this->assertEquals($getIndexItems->all()[0]->name, 'Scully');
+        $this->assertEquals($getIndexItems->all()[1]->name, 'Jake Peralta');
+        $this->assertEquals($getIndexItems->all()[2]->name, 'Amy Santiago');
     }
 
     #[Test]
@@ -117,9 +93,9 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertTrue($getIndexItems instanceof Collection);
         $this->assertEquals($getIndexItems->count(), 3);
 
-        $this->assertEquals($getIndexItems->all()[0]['title'], 'Scully');
-        $this->assertEquals($getIndexItems->all()[1]['title'], 'Jake Peralta');
-        $this->assertEquals($getIndexItems->all()[2]['title'], 'Amy Santiago');
+        $this->assertEquals($getIndexItems->all()[0]->name, 'Scully');
+        $this->assertEquals($getIndexItems->all()[1]->name, 'Jake Peralta');
+        $this->assertEquals($getIndexItems->all()[2]->name, 'Amy Santiago');
     }
 
     #[Test]
@@ -137,9 +113,9 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertTrue($getIndexItems instanceof Collection);
         $this->assertEquals($getIndexItems->count(), 3);
 
-        $this->assertEquals($getIndexItems->all()[0]['title'], 'Amy Santiago');
-        $this->assertEquals($getIndexItems->all()[1]['title'], 'Jake Peralta');
-        $this->assertEquals($getIndexItems->all()[2]['title'], 'Scully');
+        $this->assertEquals($getIndexItems->all()[0]->name, 'Amy Santiago');
+        $this->assertEquals($getIndexItems->all()[1]->name, 'Jake Peralta');
+        $this->assertEquals($getIndexItems->all()[2]->name, 'Scully');
     }
 
     #[Test]

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -59,30 +59,6 @@ class HasManyFieldtypeTest extends TestCase
     }
 
     #[Test]
-    public function can_get_index_items_with_title_format()
-    {
-        $author = Author::factory()->create();
-        $posts = Post::factory()->count(2)->create(['author_id' => $author->id]);
-
-        $this->fieldtype->setField(new Field('posts', [
-            'mode' => 'default',
-            'resource' => 'post',
-            'display' => 'Posts',
-            'type' => 'has_many',
-            'title_format' => '{{ title }} TEST {{ created_at format="Y" }}',
-        ]));
-
-        $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest);
-
-        $this->assertIsObject($getIndexItems);
-        $this->assertTrue($getIndexItems instanceof Paginator);
-        $this->assertEquals($getIndexItems->count(), 2);
-
-        $this->assertEquals($getIndexItems->first()['title'], $posts[0]->title.' TEST '.now()->format('Y'));
-        $this->assertEquals($getIndexItems->last()['title'], $posts[1]->title.' TEST '.now()->format('Y'));
-    }
-
-    #[Test]
     public function can_get_index_items_in_order_specified_in_runway_config()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.order_by', 'title');


### PR DESCRIPTION
This pull request does some refactoring around the Models Selector in Runway's built-in fieldtypes. 

Instead of returning arrays from the `getIndexItems` method, it'll return the models, which will then be transformed by JSON resources. This follows how Statamic works with the Entries fieldtype.

It'll also pull the columns for the models selector from the user's  preferences, if they have any set, rather than always using the default listable columns from the resource's blueprint.

Fixes #588.