### PR TITLE
[7.x] Improve handling of empty blueprints

### DIFF
--- a/src/GenerateBlueprint.php
+++ b/src/GenerateBlueprint.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace StatamicRadPack\Runway;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Statamic\Fields\Blueprint;
+
+class GenerateBlueprint
+{
+    protected static array $columnMappings = [
+        'integer' => 'integer',
+        'tinyint' => 'integer',
+        'bigint' => 'integer',
+        'varchar' => 'text',
+        'text' => 'textarea',
+//        'json' => 'array',
+        'timestamp' => 'date',
+    ];
+
+    public static function generate(Resource $resource): Blueprint
+    {
+        $mainSection = [];
+        $sidebarSection = [];
+
+        collect(Schema::getColumns($resource->databaseTable()))
+            ->reject(fn (array $column) => in_array($column['name'], ['id', 'created_at', 'updated_at']))
+            ->map(fn (array $column) => [
+                'name' => $column['name'],
+                'type' => static::getMatchingFieldtype($column),
+                'nullable' => $column['nullable'],
+                'default' => $column['default'],
+            ])
+            ->reject(fn (array $field) => is_null($field['type']))
+            ->each(function (array $field) use (&$mainSection, &$sidebarSection) {
+                $blueprintField = [
+                    'handle' => $field['name'],
+                    'field' => [
+                        'type' => $field['type'],
+                        'display' => (string) Str::of($field['name'])->replace('_', ' ')->title(),
+                    ],
+                ];
+
+                if (! $field['nullable']) {
+                    $blueprintField['field']['validate'] = 'required';
+                }
+
+                if (in_array($field['name'], ['slug'])) {
+                    $sidebarSection[] = $blueprintField;
+
+                    return;
+                }
+
+                $mainSection[] = $blueprintField;
+            });
+
+        return \Statamic\Facades\Blueprint::make($resource->handle())
+            ->setNamespace('runway')
+            ->setContents([
+                'tabs' => [
+                    'main' => ['fields' => $mainSection],
+                    'sidebar' => ['fields' => $sidebarSection],
+                ],
+            ])
+            ->save();
+    }
+
+    protected static function getMatchingFieldtype(array $column): ?string
+    {
+        $mapping = Arr::get(static::$columnMappings, $column['type_name']);
+
+        if (! $mapping) {
+            return null;
+        }
+
+        if (Arr::get($column, 'name') === 'slug') {
+            return 'slug';
+        }
+
+        if (Arr::get($column, 'type') === 'tinyint(1)') {
+            return 'toggle';
+        }
+
+        return $mapping;
+    }
+}

--- a/src/GenerateBlueprint.php
+++ b/src/GenerateBlueprint.php
@@ -38,7 +38,7 @@ class GenerateBlueprint
                     'handle' => $field['name'],
                     'field' => [
                         'type' => $field['type'],
-                        'display' => (string) Str::of($field['name'])->replace('_', ' ')->title(),
+                        'display' => (string) Str::of($field['name'])->headline(),
                     ],
                 ];
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -54,7 +54,7 @@ class Resource
         $blueprint = Blueprint::find("runway::{$this->handle}");
 
         if (! $blueprint) {
-            $blueprint = Blueprint::make($this->handle)->setNamespace('runway')->save();
+            $blueprint = GenerateBlueprint::generate($this);
         }
 
         return $blueprint;


### PR DESCRIPTION
Right now, when you add an Eloquent Model to your Runway config and visit that resource in the Control Panel, it'll throw an exception asking you to go to the blueprint and add some fields.

Now, with this pull request, it'll automatically create a blueprint for you and build out the fields based on your database columns. 

You can obviously go in and manualy update the blueprint to add/change/remove any fields.