### PR TITLE
[7.x] Return unlink when parent is not set

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -114,7 +114,7 @@ class BaseFieldtype extends Relationship
 
     private function getUnlinkBehavior(): string
     {
-        if ($this instanceof BelongsToFieldtype || !$this->field->parent()) {
+        if ($this instanceof BelongsToFieldtype || ! $this->field->parent()) {
             return 'unlink';
         }
 

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -114,7 +114,7 @@ class BaseFieldtype extends Relationship
 
     private function getUnlinkBehavior(): string
     {
-        if ($this instanceof BelongsToFieldtype) {
+        if ($this instanceof BelongsToFieldtype || !$this->field->parent()) {
             return 'unlink';
         }
 

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -114,7 +114,7 @@ class BaseFieldtype extends Relationship
 
     private function getUnlinkBehavior(): string
     {
-        if ($this instanceof BelongsToFieldtype || ! $this->field->parent()) {
+        if (! $this->field->parent() || $this instanceof BelongsToFieldtype) {
             return 'unlink';
         }
 


### PR DESCRIPTION
This might fix #598 . When i add this check it returns the page without errors and the runway resource that does not exist anymore will be marked red for the user to delete.