### PR TITLE
[7.x] Fix error with Has Many fieldtype when used on entries

### DIFF
--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -9,8 +9,10 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
+use Statamic\Facades\Entry;
 use Statamic\Fields\Field;
 use Statamic\Http\Requests\FilteredRequest;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use StatamicRadPack\Runway\Fieldtypes\HasManyFieldtype;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
@@ -19,7 +21,7 @@ use StatamicRadPack\Runway\Tests\TestCase;
 
 class HasManyFieldtypeTest extends TestCase
 {
-    use WithFaker;
+    use PreventsSavingStacheItemsToDisk, WithFaker;
 
     protected HasManyFieldtype $fieldtype;
 
@@ -86,6 +88,26 @@ class HasManyFieldtypeTest extends TestCase
         $fieldtype->setField($field);
 
         $this->assertEquals('delete', $fieldtype->preload()['unlinkBehavior']);
+    }
+
+    #[Test]
+    public function unlink_behavior_is_unlink_when_field_is_used_on_entry()
+    {
+        \Statamic\Facades\Collection::make('pages')->save();
+
+        $field = new Field('posts', [
+            'mode' => 'stack',
+            'resource' => 'post',
+            'display' => 'Posts',
+            'type' => 'has_many',
+        ]);
+
+        $field->setParent(Entry::make()->collection('pages'));
+
+        $fieldtype = new HasManyFieldtype;
+        $fieldtype->setField($field);
+
+        $this->assertEquals('unlink', $fieldtype->preload()['unlinkBehavior']);
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where an error would occur when using the Has Many fieldtype on an entry blueprint.

Closes #600.