### PR TITLE
[7.x] Fix augmentation on frontend routes

### DIFF
--- a/src/Routing/ResourceResponse.php
+++ b/src/Routing/ResourceResponse.php
@@ -54,6 +54,7 @@ class ResourceResponse implements Responsable
         $contents = (new View)
             ->template($this->data->template())
             ->layout($this->data->layout())
+            ->with($this->data->toAugmentedArray())
             ->cascadeContent($this->data)
             ->render();
 


### PR DESCRIPTION
This pull request fixes an issue where fields weren't being augmented correctly on frontend routes.

This issue was caused by #590, where we started passing the model to `->cascadeContent()` instead of passing the augmented array to `->with()`.

However, this meant that the data on frontend routes wasn't being augmented since [`Cascade::hydrateContent()`](https://github.com/statamic/cms/blob/6db65ff2b820b6c21d8b3c1a88c1d74c5289e981/src/View/Cascade.php#L161C48-L161C59) checks if the data (the Eloquent Model in this case) implements the `Augmentable` interface which models aren't implementing.

Since there's no way for us to add the interface in Runway's traits, we're just passing the augmented data along again to `->with()` which fixes the issue.

Fixes #606.