### PR TITLE
[7.x] Fix error when linking related model with publish states

### DIFF
--- a/src/Http/Resources/CP/ListedModel.php
+++ b/src/Http/Resources/CP/ListedModel.php
@@ -50,6 +50,7 @@ class ListedModel extends JsonResource
             'editable' => User::current()->can('edit', [$this->runwayResource, $model]),
             'viewable' => User::current()->can('view', [$this->runwayResource, $model]),
             'actions' => Action::for($model, ['resource' => $this->runwayResource->handle()]),
+            'collection' => ['dated' => false],
             $this->merge($this->values()),
         ];
     }


### PR DESCRIPTION
This pull request fixes an issue when linking a related model, when the related model's resource had publish states enabled.

Statamic's [`Selector` Vue component](https://github.com/statamic/cms/blob/c2008b387e91444c66ad74672609edc1210adddb/resources/js/components/inputs/relationship/Selector.vue#L426) checks the `collection.dated` key on items (because it presumes that the only items with publish states are going to be entries). 

So, to make everthing work, we're just returning that key from our resource.

Fixes #612.