### PR TITLE
[7.x] Fix missing title on fieldtype dropdown options

### DIFF
--- a/src/Http/Resources/CP/ListedModel.php
+++ b/src/Http/Resources/CP/ListedModel.php
@@ -43,6 +43,7 @@ class ListedModel extends JsonResource
 
         return [
             'id' => $model->getKey(),
+            'title' => $model->getAttribute($this->runwayResource->titleField()),
             'published' => $this->resource->published(),
             'status' => $this->resource->publishedStatus(),
             'edit_url' => $model->runwayEditUrl(),


### PR DESCRIPTION
This pull request fixes an issue with Runway's fieldtypes when used in Select/Typeahead modes, where the select options were missing titles.

Caused by #592.
Fixes #615.