### PR TITLE
[7.x] Minor optimisations on isJson function

### DIFF
--- a/src/Support/Json.php
+++ b/src/Support/Json.php
@@ -2,15 +2,21 @@
 
 namespace StatamicRadPack\Runway\Support;
 
+use Illuminate\Support\Str;
+
 class Json
 {
     public static function isJson($value): bool
     {
-        if (is_array($value) || is_object($value) || (is_string($value) && ! str_starts_with($value, '[') && ! str_starts_with($value, '{'))) {
+        if (
+            is_array($value)
+            || is_object($value)
+            || (is_string($value) && ! str_starts_with($value, '[') && ! str_starts_with($value, '{'))
+        ) {
             return false;
         }
 
-        // TODO: when dropping support for php8.2 implement https://www.php.net/manual/en/function.json-validate.php
+        // TODO: Replace this with json_validate when dropping support for PHP 8.2.
         return is_array(json_decode($value, true));
     }
 }

--- a/src/Support/Json.php
+++ b/src/Support/Json.php
@@ -6,7 +6,7 @@ class Json
 {
     public static function isJson($value): bool
     {
-        if (is_array($value) || is_object($value) || (is_string($value) && !str_starts_with('[', $value) && !str_starts_with('{', $value))) {
+        if (is_array($value) || is_object($value) || (is_string($value) && !str_starts_with($value, '[') && !str_starts_with($value, '{'))) {
             return false;
         }
 

--- a/src/Support/Json.php
+++ b/src/Support/Json.php
@@ -6,7 +6,7 @@ class Json
 {
     public static function isJson($value): bool
     {
-        if (is_array($value) || is_object($value) || (is_string($value) && !str_starts_with($value, '[') && !str_starts_with($value, '{'))) {
+        if (is_array($value) || is_object($value) || (is_string($value) && ! str_starts_with($value, '[') && ! str_starts_with($value, '{'))) {
             return false;
         }
 

--- a/src/Support/Json.php
+++ b/src/Support/Json.php
@@ -2,8 +2,6 @@
 
 namespace StatamicRadPack\Runway\Support;
 
-use Illuminate\Support\Str;
-
 class Json
 {
     public static function isJson($value): bool

--- a/src/Support/Json.php
+++ b/src/Support/Json.php
@@ -6,10 +6,11 @@ class Json
 {
     public static function isJson($value): bool
     {
-        if (is_array($value) || is_object($value)) {
+        if (is_array($value) || is_object($value) || (is_string($value) && !str_starts_with('[', $value) && !str_starts_with('{', $value))) {
             return false;
         }
 
+        // TODO: when dropping support for php8.2 implement https://www.php.net/manual/en/function.json-validate.php
         return is_array(json_decode($value, true));
     }
 }


### PR DESCRIPTION
Profiling i noticed (in my case) jsJson is called over 10k times in the code, causing wall time to be quite high.
On large strings `json_decode` is a heavy operation, if we perform some simpler string checks we can hopefully reduce some json_decode operations.

once https://www.php.net/manual/en/function.json-validate.php can be used this can further optimise the check since it's what json_decode uses before actually attempting to decode, thus we can skip the decoding itself.