### PR TITLE
[7.x] Add check whether value is null

### DIFF
--- a/src/Support/Json.php
+++ b/src/Support/Json.php
@@ -7,7 +7,8 @@ class Json
     public static function isJson($value): bool
     {
         if (
-            is_array($value)
+            $value === null
+            || is_array($value)
             || is_object($value)
             || (is_string($value) && ! str_starts_with($value, '[') && ! str_starts_with($value, '{'))
         ) {


### PR DESCRIPTION
I've seen a couple warnings pop up during development

> LOG.warning: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in vendor/doublethreedigital/runway/src/Support/Json.php on line 18

So we should probably add a check whether we're dealing with a null value as well