### PR TITLE
[7.x] Fix error when augmenting model mutators

### DIFF
--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -9,6 +9,7 @@ use Statamic\Data\AbstractAugmented;
 use Statamic\Fields\Field;
 use Statamic\Fields\Value;
 use Statamic\Statamic;
+use Statamic\Support\Arr;
 use StatamicRadPack\Runway\Runway;
 
 class AugmentedModel extends AbstractAugmented
@@ -187,9 +188,8 @@ class AugmentedModel extends AbstractAugmented
                 }
 
                 $attributes = $this->data->getAttributes();
-                $value = isset($attributes[$handle]) ? $attributes[$handle] : null;
 
-                return ($attribute->get)($value, $attributes);
+                return ($attribute->get)(Arr::get($attributes, $handle), $attributes);
             },
             $handle,
             $this->fieldtype($handle),

--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -186,7 +186,9 @@ class AugmentedModel extends AbstractAugmented
                     return $this->data->getAttribute($handle);
                 }
 
-                return ($attribute->get)();
+                $attributes = $this->data->getAttributes();
+                $value = isset($attributes[$handle]) ? $attributes[$handle] : null;
+                return ($attribute->get)($value, $attributes);
             },
             $handle,
             $this->fieldtype($handle),

--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -188,6 +188,7 @@ class AugmentedModel extends AbstractAugmented
 
                 $attributes = $this->data->getAttributes();
                 $value = isset($attributes[$handle]) ? $attributes[$handle] : null;
+
                 return ($attribute->get)($value, $attributes);
             },
             $handle,

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -22,6 +22,7 @@ class AugmentedModelTest extends TestCase
             'title' => 'My First Post',
             'slug' => 'my-first-post',
             'body' => 'Blah blah blah...',
+            'mutated_value' => 'value is mutated',
             'author_id' => $author->id,
         ]);
 
@@ -33,6 +34,9 @@ class AugmentedModelTest extends TestCase
         $this->assertEquals('my-first-post', $augmented->get('slug')->value());
         $this->assertEquals('Blah blah blah...', $augmented->get('body')->value());
         $this->assertEquals('2020-01-01 13:46:12', $augmented->get('created_at')->value()->format('Y-m-d H:i:s'));
+        $this->assertEquals('/posts/my-first-post', $augmented->get('url')->value());
+        $this->assertEquals('value', $post->getAttributes()['mutated_value']);
+        $this->assertEquals('value is mutated', $augmented->get('mutated_value')->value());
         $this->assertEquals('/posts/my-first-post', $augmented->get('url')->value());
 
         $this->assertIsArray($augmented->get('author')->value());

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -22,7 +22,7 @@ class AugmentedModelTest extends TestCase
             'title' => 'My First Post',
             'slug' => 'my-first-post',
             'body' => 'Blah blah blah...',
-            'mutated_value' => 'value is mutated',
+            'mutated_value' => 'value',
             'author_id' => $author->id,
         ]);
 
@@ -35,7 +35,6 @@ class AugmentedModelTest extends TestCase
         $this->assertEquals('Blah blah blah...', $augmented->get('body')->value());
         $this->assertEquals('2020-01-01 13:46:12', $augmented->get('created_at')->value()->format('Y-m-d H:i:s'));
         $this->assertEquals('/posts/my-first-post', $augmented->get('url')->value());
-        $this->assertEquals('value', $post->getAttributes()['mutated_value']);
         $this->assertEquals('value is mutated', $augmented->get('mutated_value')->value());
 
         $this->assertIsArray($augmented->get('author')->value());

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -22,7 +22,7 @@ class AugmentedModelTest extends TestCase
             'title' => 'My First Post',
             'slug' => 'my-first-post',
             'body' => 'Blah blah blah...',
-            'mutated_value' => 'value',
+            'mutated_value' => 'Value',
             'author_id' => $author->id,
         ]);
 
@@ -35,7 +35,7 @@ class AugmentedModelTest extends TestCase
         $this->assertEquals('Blah blah blah...', $augmented->get('body')->value());
         $this->assertEquals('2020-01-01 13:46:12', $augmented->get('created_at')->value()->format('Y-m-d H:i:s'));
         $this->assertEquals('/posts/my-first-post', $augmented->get('url')->value());
-        $this->assertEquals('value is mutated', $augmented->get('mutated_value')->value());
+        $this->assertEquals('Value is mutated', $augmented->get('mutated_value')->value());
 
         $this->assertIsArray($augmented->get('author')->value());
         $this->assertEquals($author->id, $augmented->get('author')->value()['id']->value());

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -37,7 +37,6 @@ class AugmentedModelTest extends TestCase
         $this->assertEquals('/posts/my-first-post', $augmented->get('url')->value());
         $this->assertEquals('value', $post->getAttributes()['mutated_value']);
         $this->assertEquals('value is mutated', $augmented->get('mutated_value')->value());
-        $this->assertEquals('/posts/my-first-post', $augmented->get('url')->value());
 
         $this->assertIsArray($augmented->get('author')->value());
         $this->assertEquals($author->id, $augmented->get('author')->value()['id']->value());

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -22,7 +22,6 @@ class AugmentedModelTest extends TestCase
             'title' => 'My First Post',
             'slug' => 'my-first-post',
             'body' => 'Blah blah blah...',
-            'mutated_value' => 'Value',
             'author_id' => $author->id,
         ]);
 
@@ -35,7 +34,6 @@ class AugmentedModelTest extends TestCase
         $this->assertEquals('Blah blah blah...', $augmented->get('body')->value());
         $this->assertEquals('2020-01-01 13:46:12', $augmented->get('created_at')->value()->format('Y-m-d H:i:s'));
         $this->assertEquals('/posts/my-first-post', $augmented->get('url')->value());
-        $this->assertEquals('Value is mutated', $augmented->get('mutated_value')->value());
 
         $this->assertIsArray($augmented->get('author')->value());
         $this->assertEquals($author->id, $augmented->get('author')->value()['id']->value());
@@ -82,5 +80,15 @@ class AugmentedModelTest extends TestCase
         $augmented = new AugmentedModel($post);
 
         $this->assertEquals('This is an appended value.', $augmented->get('appended_value')->value());
+    }
+
+    #[Test]
+    public function it_gets_value_from_mutator()
+    {
+        $post = Post::factory()->create(['mutated_value' => 'Foo']);
+
+        $augmented = new AugmentedModel($post);
+
+        $this->assertEquals('Foo is a mutated value.', $augmented->get('mutated_value')->value());
     }
 }

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -15,7 +15,7 @@ class Post extends Model
     use HasFactory, HasRunwayResource, RunwayRoutes;
 
     protected $fillable = [
-        'title', 'slug', 'body', 'values', 'external_links', 'author_id', 'sort_order', 'published',
+        'title', 'slug', 'body', 'values', 'external_links', 'author_id', 'sort_order', 'published', 'mutated_value'
     ];
 
     protected $appends = [
@@ -67,6 +67,16 @@ class Post extends Model
         return Attribute::make(
             get: function () {
                 return 'This is an appended value.';
+            }
+        );
+    }
+
+    public function mutatedValue(): Attribute
+    {
+        return Attribute::make(
+            set: fn ($value) => str_replace(' is mutated', '', $value),
+            get: function ($value, $attributes) {
+                return $value . ' is mutated';
             }
         );
     }

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -75,7 +75,7 @@ class Post extends Model
     public function mutatedValue(): Attribute
     {
         return Attribute::make(
-            get: fn (string $value, array $attributes) => "{$value} is mutated",
+            get: fn (string $value, array $attributes) => "{$value} is a mutated value.",
         );
     }
 

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -15,7 +15,7 @@ class Post extends Model
     use HasFactory, HasRunwayResource, RunwayRoutes;
 
     protected $fillable = [
-        'title', 'slug', 'body', 'values', 'external_links', 'author_id', 'sort_order', 'published', 'mutated_value'
+        'title', 'slug', 'body', 'values', 'external_links', 'author_id', 'sort_order', 'published', 'mutated_value',
     ];
 
     protected $appends = [

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -74,7 +74,6 @@ class Post extends Model
     public function mutatedValue(): Attribute
     {
         return Attribute::make(
-            set: fn ($value) => str_replace(' is mutated', '', $value),
             get: function ($value, $attributes) {
                 return $value.' is mutated';
             }

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -9,7 +9,6 @@ use Statamic\Facades\Blink;
 use StatamicRadPack\Runway\Routing\Traits\RunwayRoutes;
 use StatamicRadPack\Runway\Tests\Fixtures\Database\Factories\PostFactory;
 use StatamicRadPack\Runway\Traits\HasRunwayResource;
-use function DI\get;
 
 class Post extends Model
 {

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -76,7 +76,7 @@ class Post extends Model
         return Attribute::make(
             set: fn ($value) => str_replace(' is mutated', '', $value),
             get: function ($value, $attributes) {
-                return $value . ' is mutated';
+                return $value.' is mutated';
             }
         );
     }

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -9,6 +9,7 @@ use Statamic\Facades\Blink;
 use StatamicRadPack\Runway\Routing\Traits\RunwayRoutes;
 use StatamicRadPack\Runway\Tests\Fixtures\Database\Factories\PostFactory;
 use StatamicRadPack\Runway\Traits\HasRunwayResource;
+use function DI\get;
 
 class Post extends Model
 {
@@ -74,9 +75,7 @@ class Post extends Model
     public function mutatedValue(): Attribute
     {
         return Attribute::make(
-            get: function ($value, $attributes) {
-                return $value.' is mutated';
-            }
+            get: fn (string $value, array $attributes) => "{$value} is mutated",
         );
     }
 

--- a/tests/__fixtures__/database/factories/PostFactory.php
+++ b/tests/__fixtures__/database/factories/PostFactory.php
@@ -29,6 +29,7 @@ class PostFactory extends Factory
             'body' => implode(' ', $this->faker->paragraphs(10)),
             'author_id' => Author::factory()->create()->id,
             'published' => true,
+            'mutated_value' => 'Foo',
         ];
     }
 

--- a/tests/__fixtures__/database/migrations/2020_12_12_220453_create_posts_table.php
+++ b/tests/__fixtures__/database/migrations/2020_12_12_220453_create_posts_table.php
@@ -25,6 +25,7 @@ class CreatePostsTable extends Migration
             $table->datetime('start_date')->nullable();
             $table->datetime('end_date')->nullable();
             $table->boolean('published')->default(false);
+            $table->string('mutated_value')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Fixes #627 

Passes the `$value` and `$attributes` values to the models Attributes getter.