### PR TITLE
[7.x] Fix issue where HasMany relationship wasn't being resolved

### DIFF
--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -63,20 +63,20 @@ trait PreparesModels
                 }
 
                 if ($field->fieldtype() instanceof HasManyFieldtype) {
-                    // When there are ID's on the model's $runwayRelationships property, use them instead of querying the relationship.
+                    // Use IDs from the model's $runwayRelationships property, if there are any.
                     if (array_key_exists($field->handle(), $model->runwayRelationships)) {
-                        return [$field->handle() => Arr::get($model->runwayRelationships, $field->handle())];
+                        $value = Arr::get($model->runwayRelationships, $field->handle());
                     }
 
-                    $relationshipName = $resource->eloquentRelationships()->get($field->handle());
+                    // When re-ordering is enabled, ensure the models are returned in the correct order.
+                    if ($field->get('reorderable', false)) {
+                        $orderColumn = $field->get('order_column');
+                        $relationshipName = $resource->eloquentRelationships()->get($field->handle());
 
-                    $query = $model->{$relationshipName}();
-
-                    if ($field->get('reorderable')) {
-                        $query->reorder($field->get('order_column'), 'ASC');
+                        $value = $model->{$relationshipName}()
+                            ->reorder($orderColumn, 'ASC')
+                            ->get();
                     }
-
-                    $value = $query->get();
                 }
 
                 return [$field->handle() => $value];

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -63,20 +63,20 @@ trait PreparesModels
                 }
 
                 if ($field->fieldtype() instanceof HasManyFieldtype) {
-                    // Use IDs from the model's $runwayRelationships property, if there are any.
+                    // When there are ID's on the model's $runwayRelationships property, use them instead of querying the relationship.
                     if (array_key_exists($field->handle(), $model->runwayRelationships)) {
-                        $value = Arr::get($model->runwayRelationships, $field->handle());
+                        return [$field->handle() => Arr::get($model->runwayRelationships, $field->handle())];
                     }
 
-                    // When re-ordering is enabled, ensure the models are returned in the correct order.
-                    if ($field->get('reorderable', false)) {
-                        $orderColumn = $field->get('order_column');
-                        $relationshipName = $resource->eloquentRelationships()->get($field->handle());
+                    $relationshipName = $resource->eloquentRelationships()->get($field->handle());
 
-                        $value = $model->{$relationshipName}()
-                            ->reorder($orderColumn, 'ASC')
-                            ->get();
+                    $query = $model->{$relationshipName}();
+
+                    if ($field->get('reorderable')) {
+                        $query->reorder($field->get('order_column'), 'ASC');
                     }
+
+                    $value = $query->get();
                 }
 
                 return [$field->handle() => $value];

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -63,6 +63,8 @@ trait PreparesModels
                 }
 
                 if ($field->fieldtype() instanceof HasManyFieldtype) {
+                    $value = data_get($model, $resource->eloquentRelationships()->get($field->handle()));
+
                     // Use IDs from the model's $runwayRelationships property, if there are any.
                     if (array_key_exists($field->handle(), $model->runwayRelationships)) {
                         $value = Arr::get($model->runwayRelationships, $field->handle());


### PR DESCRIPTION
This pull request fixes an issue where HasMany relationships weren't being resolved if the field handle differed from the `relationship_name`.

For example: 

```yaml
-
  handle: shipping_addresses
  field:
    resource: organization_shipping_address
    relationship_name: shippingAddresses
    type: has_many
    display: 'Shipping addresses'
    sortable: false
```

Even though the field handle was the "same" as the relationship name, but slugified, doing `$model->shipping_addresses` wouldn't work.

This PR fixes it by getting the correct relationship name, and calling that attribute instead.

Fixes #624.