### PR TITLE
[7.x] Fix error when running resource actions

### DIFF
--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -24,7 +24,7 @@
         create-another-url="{{ cp_route('runway.create', ['resource' => $resource->handle()]) }}"
         initial-listing-url="{{ cp_route('runway.index', ['resource' => $resource->handle()]) }}"
         :initial-item-actions="{{ json_encode($itemActions) }}"
-        item-action-url="{{ cp_route('runway.actions.run', ['resource' => $resource->handle()]) }}"
+        item-action-url="{{ cp_route('runway.models.actions.run', ['resource' => $resource->handle()]) }}"
         :revisions-enabled="{{ $str::bool($revisionsEnabled) }}"
     ></runway-publish-form>
 

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use StatamicRadPack\Runway\Http\Controllers\CP\ModelActionController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ModelRevisionsController;
 use StatamicRadPack\Runway\Http\Controllers\CP\PublishedModelsController;
-use StatamicRadPack\Runway\Http\Controllers\CP\ModelActionController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ResourceActionController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ResourceController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ResourceListingController;

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use StatamicRadPack\Runway\Http\Controllers\CP\ModelRevisionsController;
 use StatamicRadPack\Runway\Http\Controllers\CP\PublishedModelsController;
+use StatamicRadPack\Runway\Http\Controllers\CP\ModelActionController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ResourceActionController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ResourceController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ResourceListingController;
@@ -10,10 +11,13 @@ use StatamicRadPack\Runway\Http\Controllers\CP\RestoreModelRevisionController;
 
 Route::name('runway.')->prefix('runway')->group(function () {
     Route::get('/{resource}', [ResourceController::class, 'index'])->name('index');
-
     Route::get('{resource}/listing-api', [ResourceListingController::class, 'index'])->name('listing-api');
-    Route::post('{resource}/actions', [ResourceActionController::class, 'runAction'])->name('actions.run');
+
+    Route::post('{resource}/actions', [ResourceActionController::class, 'run'])->name('actions.run');
     Route::post('{resource}/actions/list', [ResourceActionController::class, 'bulkActionsList'])->name('actions.bulk');
+
+    Route::post('{resource}/models/actions', [ModelActionController::class, 'runAction'])->name('models.actions.run');
+    Route::post('{resource}/models/actions/list', [ModelActionController::class, 'bulkActionsList'])->name('models.actions.bulk');
 
     Route::get('{resource}/create', [ResourceController::class, 'create'])->name('create');
     Route::post('{resource}/create', [ResourceController::class, 'store'])->name('store');

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -14,7 +14,6 @@ Route::name('runway.')->prefix('runway')->group(function () {
     Route::get('{resource}/listing-api', [ResourceListingController::class, 'index'])->name('listing-api');
 
     Route::post('{resource}/actions', [ResourceActionController::class, 'run'])->name('actions.run');
-    Route::post('{resource}/actions/list', [ResourceActionController::class, 'bulkActionsList'])->name('actions.bulk');
 
     Route::post('{resource}/models/actions', [ModelActionController::class, 'runAction'])->name('models.actions.run');
     Route::post('{resource}/models/actions/list', [ModelActionController::class, 'bulkActionsList'])->name('models.actions.bulk');

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -61,7 +61,7 @@ class HasManyFieldtype extends BaseFieldtype
     public function preload()
     {
         return array_merge(parent::preload(), [
-            'actionUrl' => cp_route('runway.actions.run', [
+            'actionUrl' => cp_route('runway.models.actions.run', [
                 'resource' => $this->config('resource'),
             ]),
         ]);

--- a/src/Http/Controllers/CP/ModelActionController.php
+++ b/src/Http/Controllers/CP/ModelActionController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace StatamicRadPack\Runway\Http\Controllers\CP;
+
+use Illuminate\Http\Request;
+use Statamic\Facades\Action;
+use Statamic\Http\Controllers\CP\ActionController;
+use StatamicRadPack\Runway\Resource;
+
+class ModelActionController extends ActionController
+{
+    use Traits\ExtractsFromModelFields;
+
+    protected $resource;
+
+    public function runAction(Request $request, Resource $resource)
+    {
+        $this->resource = $resource;
+
+        return parent::run($request);
+    }
+
+    public function bulkActionsList(Request $request, Resource $resource)
+    {
+        $this->resource = $resource;
+
+        return parent::bulkActions($request);
+    }
+
+    protected function getSelectedItems($items, $context)
+    {
+        return $this->resource->findMany($items);
+    }
+
+    protected function getItemData($model, $context): array
+    {
+        $blueprint = $this->resource->blueprint();
+
+        [$values] = $this->extractFromFields($model, $this->resource, $blueprint);
+
+        return [
+            'title' => $model->getAttribute($this->resource->titleField()),
+            'values' => array_merge($values, ['id' => $model->getKey()]),
+            'itemActions' => Action::for($model, $context),
+        ];
+    }
+}

--- a/src/Http/Controllers/CP/ResourceActionController.php
+++ b/src/Http/Controllers/CP/ResourceActionController.php
@@ -2,46 +2,13 @@
 
 namespace StatamicRadPack\Runway\Http\Controllers\CP;
 
-use Illuminate\Http\Request;
-use Statamic\Facades\Action;
 use Statamic\Http\Controllers\CP\ActionController;
-use StatamicRadPack\Runway\Resource;
+use StatamicRadPack\Runway\Runway;
 
 class ResourceActionController extends ActionController
 {
-    use Traits\ExtractsFromModelFields;
-
-    protected $resource;
-
-    public function runAction(Request $request, Resource $resource)
-    {
-        $this->resource = $resource;
-
-        return parent::run($request);
-    }
-
-    public function bulkActionsList(Request $request, Resource $resource)
-    {
-        $this->resource = $resource;
-
-        return parent::bulkActions($request);
-    }
-
     protected function getSelectedItems($items, $context)
     {
-        return $this->resource->findMany($items);
-    }
-
-    protected function getItemData($model, $context): array
-    {
-        $blueprint = $this->resource->blueprint();
-
-        [$values] = $this->extractFromFields($model, $this->resource, $blueprint);
-
-        return [
-            'title' => $model->getAttribute($this->resource->titleField()),
-            'values' => array_merge($values, ['id' => $model->getKey()]),
-            'itemActions' => Action::for($model, $context),
-        ];
+        return $items->map(fn ($item) => Runway::findResource($item));
     }
 }

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -44,7 +44,7 @@ class ResourceController extends CpController
                 ->rejectUnlisted()
                 ->values(),
             'filters' => Scope::filters('runway', ['resource' => $resource->handle()]),
-            'actionUrl' => cp_route('runway.actions.run', ['resource' => $resource->handle()]),
+            'actionUrl' => cp_route('runway.models.actions.run', ['resource' => $resource->handle()]),
             'primaryColumn' => $this->getPrimaryColumn($resource),
             'actions' => Action::for($resource, ['view' => 'form']),
         ]);

--- a/tests/Console/Commands/GenerateMigrationTest.php
+++ b/tests/Console/Commands/GenerateMigrationTest.php
@@ -19,7 +19,7 @@ class GenerateMigrationTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -37,7 +37,7 @@ class GenerateMigrationTest extends TestCase
         });
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -21,7 +21,7 @@ class BelongsToFieldtypeTest extends TestCase
 
     protected BelongsToFieldtype $fieldtype;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -25,7 +25,7 @@ class HasManyFieldtypeTest extends TestCase
 
     protected HasManyFieldtype $fieldtype;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -9,7 +9,7 @@ use StatamicRadPack\Runway\Tests\TestCase;
 
 class ApiControllerTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Http/Controllers/CP/ModelActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ModelActionControllerTest.php
@@ -10,7 +10,7 @@ use StatamicRadPack\Runway\Tests\TestCase;
 
 class ModelActionControllerTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Http/Controllers/CP/ModelActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ModelActionControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace StatamicRadPack\Runway\Tests\Http\Controllers\CP;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Actions\Action;
+use Statamic\Facades\User;
+use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
+use StatamicRadPack\Runway\Tests\TestCase;
+
+class ModelActionControllerTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        FooAction::register();
+    }
+
+    #[Test]
+    public function can_run_action()
+    {
+        $post = Post::factory()->create();
+
+        $this->assertFalse(FooAction::$hasRun);
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->post('/cp/runway/post/models/actions', [
+                'action' => 'foo',
+                'selections' => [$post->id],
+                'values' => [],
+            ])
+            ->assertOk()
+            ->assertJson(['message' => 'Foo action run!']);
+
+        $this->assertTrue(FooAction::$hasRun);
+    }
+
+    #[Test]
+    public function can_get_bulk_actions_list()
+    {
+        $post = Post::factory()->create();
+
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->post('/cp/runway/post/models/actions/list', [
+                'selections' => [$post->id],
+            ])
+            ->assertOk()
+            ->assertJsonPath('0.handle', 'unpublish');
+    }
+}
+
+class FooAction extends Action
+{
+    protected static $handle = 'foo';
+
+    public static bool $hasRun = false;
+
+    public function run($items, $values)
+    {
+        static::$hasRun = true;
+
+        return 'Foo action run!';
+    }
+}

--- a/tests/Http/Controllers/CP/ModelRevisionsControllerTest.php
+++ b/tests/Http/Controllers/CP/ModelRevisionsControllerTest.php
@@ -13,7 +13,7 @@ class ModelRevisionsControllerTest extends TestCase
 {
     private $dir;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -22,7 +22,7 @@ class ModelRevisionsControllerTest extends TestCase
         config(['statamic.revisions.path' => $this->dir]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Folder::delete($this->dir);
 

--- a/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
+++ b/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
@@ -12,7 +12,7 @@ class PublishedModelsControllerTest extends TestCase
 {
     private $dir;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -21,7 +21,7 @@ class PublishedModelsControllerTest extends TestCase
         config(['statamic.revisions.path' => $this->dir]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Folder::delete($this->dir);
 

--- a/tests/Http/Controllers/CP/ResourceActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceActionControllerTest.php
@@ -34,20 +34,6 @@ class ResourceActionControllerTest extends TestCase
 
         $this->assertTrue(FooAction::$hasRun);
     }
-
-    #[Test]
-    public function can_get_bulk_actions_list()
-    {
-        $post = Post::factory()->create();
-
-        $this
-            ->actingAs(User::make()->makeSuper()->save())
-            ->post('/cp/runway/post/actions/list', [
-                'selections' => ['post'],
-            ])
-            ->assertOk()
-            ->assertJsonPath('0.handle', 'unpublish');
-    }
 }
 
 class BarAction extends Action

--- a/tests/Http/Controllers/CP/ResourceActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceActionControllerTest.php
@@ -5,7 +5,6 @@ namespace StatamicRadPack\Runway\Tests\Http\Controllers\CP;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Actions\Action;
 use Statamic\Facades\User;
-use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 use StatamicRadPack\Runway\Tests\TestCase;
 
 class ResourceActionControllerTest extends TestCase

--- a/tests/Http/Controllers/CP/ResourceActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceActionControllerTest.php
@@ -10,7 +10,7 @@ use StatamicRadPack\Runway\Tests\TestCase;
 
 class ResourceActionControllerTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Http/Controllers/CP/ResourceActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceActionControllerTest.php
@@ -20,19 +20,17 @@ class ResourceActionControllerTest extends TestCase
     #[Test]
     public function can_run_action()
     {
-        $post = Post::factory()->create();
-
         $this->assertFalse(FooAction::$hasRun);
 
         $this
             ->actingAs(User::make()->makeSuper()->save())
             ->post('/cp/runway/post/actions', [
-                'action' => 'foo',
-                'selections' => [$post->id],
+                'action' => 'bar',
+                'selections' => ['post'],
                 'values' => [],
             ])
             ->assertOk()
-            ->assertJson(['message' => 'Foo action run!']);
+            ->assertJson(['message' => 'Bar action run!']);
 
         $this->assertTrue(FooAction::$hasRun);
     }
@@ -45,16 +43,16 @@ class ResourceActionControllerTest extends TestCase
         $this
             ->actingAs(User::make()->makeSuper()->save())
             ->post('/cp/runway/post/actions/list', [
-                'selections' => [$post->id],
+                'selections' => ['post'],
             ])
             ->assertOk()
             ->assertJsonPath('0.handle', 'unpublish');
     }
 }
 
-class FooAction extends Action
+class BarAction extends Action
 {
-    protected static $handle = 'foo';
+    protected static $handle = 'bar';
 
     public static bool $hasRun = false;
 
@@ -62,6 +60,6 @@ class FooAction extends Action
     {
         static::$hasRun = true;
 
-        return 'Foo action run!';
+        return 'Bar action run!';
     }
 }

--- a/tests/Http/Controllers/CP/ResourceActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceActionControllerTest.php
@@ -14,13 +14,13 @@ class ResourceActionControllerTest extends TestCase
     {
         parent::setUp();
 
-        FooAction::register();
+        BarAction::register();
     }
 
     #[Test]
     public function can_run_action()
     {
-        $this->assertFalse(FooAction::$hasRun);
+        $this->assertFalse(BarAction::$hasRun);
 
         $this
             ->actingAs(User::make()->makeSuper()->save())
@@ -32,7 +32,7 @@ class ResourceActionControllerTest extends TestCase
             ->assertOk()
             ->assertJson(['message' => 'Bar action run!']);
 
-        $this->assertTrue(FooAction::$hasRun);
+        $this->assertTrue(BarAction::$hasRun);
     }
 }
 

--- a/tests/Http/Controllers/CP/RestoreModelRevisionController.php
+++ b/tests/Http/Controllers/CP/RestoreModelRevisionController.php
@@ -12,7 +12,7 @@ class RestoreModelRevisionController extends TestCase
 {
     private $dir;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -21,7 +21,7 @@ class RestoreModelRevisionController extends TestCase
         config(['statamic.revisions.path' => $this->dir]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Folder::delete($this->dir);
 

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -17,7 +17,7 @@ class RunwayTagTest extends TestCase
 {
     public $tag;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This pull request fixes an error when running resource actions, where code was expecting a `Model` instance to be passed in when it was a `Resource`.

It looks like "resource actions" and "model actions" were sharing the same controller. This PR splits them out to match how Statamic handles collection/entry actions.

I have no idea how resource actions were working in the first place. 🤷‍♂️

Fixes #637.