### PR TITLE
[7.x] Respect "Duplicate" toggle on fields

### DIFF
--- a/src/Actions/DuplicateModel.php
+++ b/src/Actions/DuplicateModel.php
@@ -64,7 +64,7 @@ class DuplicateModel extends Action
 
     private function duplicateModel(Model $original, Resource $resource): Model
     {
-        $model = $original->replicate();
+        $model = $original->replicate($resource->blueprint()->fields()->all()->reject->shouldBeDuplicated()->keys()->all());
 
         if ($resource->titleField()) {
             $model->setAttribute($resource->titleField(), $original->getAttribute($resource->titleField()).' (Duplicate)');

--- a/tests/Actions/DuplicateModelTest.php
+++ b/tests/Actions/DuplicateModelTest.php
@@ -156,6 +156,29 @@ class DuplicateModelTest extends TestCase
 
         $duplicate = Post::query()->whereNot('id', $post->id)->first();
 
+        $this->assertEquals('Hello World (Duplicate)', $duplicate->title);
+        $this->assertNotNull($duplicate->start_date);
+        $this->assertFalse($duplicate->published());
+    }
+
+    #[Test]
+    public function only_duplicates_fields_where_duplication_is_enabled()
+    {
+        $blueprint = Blueprint::find('runway::post');
+        $blueprint->ensureFieldHasConfig('start_date', ['duplicate' => false]);
+
+        Blueprint::shouldReceive('find')
+            ->with('runway::post')
+            ->andReturn($blueprint);
+
+        $post = Post::factory()->create(['title' => 'Hello World', 'start_date' => now()]);
+
+        (new DuplicateModel)->run(collect([$post]), []);
+
+        $duplicate = Post::query()->whereNot('id', $post->id)->first();
+
+        $this->assertEquals('Hello World (Duplicate)', $duplicate->title);
+        $this->assertNull($duplicate->start_date);
         $this->assertFalse($duplicate->published());
     }
 }

--- a/tests/Actions/DuplicateModelTest.php
+++ b/tests/Actions/DuplicateModelTest.php
@@ -72,7 +72,7 @@ class DuplicateModelTest extends TestCase
     }
 
     #[Test]
-    public function is_not_visible_to_entry()
+    public function is_not_visible_to_an_entry()
     {
         Collection::make('posts')->save();
 

--- a/tests/Console/Commands/GenerateMigrationTest.php
+++ b/tests/Console/Commands/GenerateMigrationTest.php
@@ -19,7 +19,7 @@ class GenerateMigrationTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -37,7 +37,7 @@ class GenerateMigrationTest extends TestCase
         });
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -21,7 +21,7 @@ class BelongsToFieldtypeTest extends TestCase
 
     protected BelongsToFieldtype $fieldtype;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -25,7 +25,7 @@ class HasManyFieldtypeTest extends TestCase
 
     protected HasManyFieldtype $fieldtype;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -9,7 +9,7 @@ use StatamicRadPack\Runway\Tests\TestCase;
 
 class ApiControllerTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Http/Controllers/CP/ModelRevisionsControllerTest.php
+++ b/tests/Http/Controllers/CP/ModelRevisionsControllerTest.php
@@ -13,7 +13,7 @@ class ModelRevisionsControllerTest extends TestCase
 {
     private $dir;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -22,7 +22,7 @@ class ModelRevisionsControllerTest extends TestCase
         config(['statamic.revisions.path' => $this->dir]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Folder::delete($this->dir);
 

--- a/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
+++ b/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
@@ -12,7 +12,7 @@ class PublishedModelsControllerTest extends TestCase
 {
     private $dir;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -21,7 +21,7 @@ class PublishedModelsControllerTest extends TestCase
         config(['statamic.revisions.path' => $this->dir]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Folder::delete($this->dir);
 

--- a/tests/Http/Controllers/CP/ResourceActionControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceActionControllerTest.php
@@ -10,7 +10,7 @@ use StatamicRadPack\Runway\Tests\TestCase;
 
 class ResourceActionControllerTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Http/Controllers/CP/RestoreModelRevisionController.php
+++ b/tests/Http/Controllers/CP/RestoreModelRevisionController.php
@@ -12,7 +12,7 @@ class RestoreModelRevisionController extends TestCase
 {
     private $dir;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -21,7 +21,7 @@ class RestoreModelRevisionController extends TestCase
         config(['statamic.revisions.path' => $this->dir]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Folder::delete($this->dir);
 

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -17,7 +17,7 @@ class RunwayTagTest extends TestCase
 {
     public $tag;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/__fixtures__/database/factories/PostFactory.php
+++ b/tests/__fixtures__/database/factories/PostFactory.php
@@ -28,6 +28,7 @@ class PostFactory extends Factory
             'slug' => Str::slug($title),
             'body' => implode(' ', $this->faker->paragraphs(10)),
             'author_id' => Author::factory()->create()->id,
+            'start_date' => now(),
             'published' => true,
             'mutated_value' => 'Foo',
         ];


### PR DESCRIPTION
This pull request fixes an issue with Runway's "Duplicate" action where it wasn't respecting the "Duplicate" option on fields. Now it does.

Closes #635.