### PR TITLE
[7.x] Prevent Belongs To fields being saved as an array in entry data

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -133,6 +133,15 @@ abstract class BaseFieldtype extends Relationship
         return 'unlink';
     }
 
+    public function process($data)
+    {
+        if ($this->config('max_items') === 1 && ! $this->field->parent() instanceof Model) {
+            return Arr::first($data);
+        }
+
+        return parent::process($data);
+    }
+
     public function getIndexItems($request)
     {
         $resource = Runway::findResource($this->config('resource'));


### PR DESCRIPTION
This pull request fixes an issue where Belongs To fields were being saved as arrays, instead of integers/strings, when saved in a non-model context (eg. in an entry blueprint).

Fixes #640.