### PR TITLE
[7.x] Only published models should be returned by augmentation

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -286,6 +286,7 @@ abstract class BaseFieldtype extends Relationship
 
                 return $model;
             })
+            ->when($resource->hasPublishStates(), fn ($collection) => $collection->filter(fn ($model) => $model->published()))
             ->filter();
     }
 


### PR DESCRIPTION
This pull request fixes an issue where unpublished models were being returned when augmenting Runway relationships.