### PR TITLE
[7.x] Check if relationship method exists before calling it

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -114,8 +114,8 @@ abstract class BaseFieldtype extends Relationship
 
     private function getUnlinkBehavior(): string
     {
-        if ($this->field->parent() instanceof Model && $this instanceof HasManyFieldtype) {
-            $relationshipName = $this->config('relationship_name') ?? $this->field->handle();
+        $relationshipName = $this->config('relationship_name') ?? $this->field->handle();
+        if ($this->field->parent() instanceof Model && $this instanceof HasManyFieldtype && method_exists($this->field->parent(), $relationshipName)) {
             $relationship = $this->field->parent()->{$relationshipName}();
             if ($relationship instanceof HasMany) {
                 $foreignKey = $relationship->getQualifiedForeignKeyName();

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -115,8 +115,14 @@ abstract class BaseFieldtype extends Relationship
     private function getUnlinkBehavior(): string
     {
         $relationshipName = $this->config('relationship_name') ?? $this->field->handle();
-        if ($this->field->parent() instanceof Model && $this instanceof HasManyFieldtype && method_exists($this->field->parent(), $relationshipName)) {
+
+        if (
+            $this->field->parent() instanceof Model
+            && $this instanceof HasManyFieldtype
+            && method_exists($this->field->parent(), $relationshipName)
+        ) {
             $relationship = $this->field->parent()->{$relationshipName}();
+
             if ($relationship instanceof HasMany) {
                 $foreignKey = $relationship->getQualifiedForeignKeyName();
 


### PR DESCRIPTION
In our situation we have a field "products" in a page builder fieldset, it is a HasMany field that links to the Product runway model. However there's no relationship set on the models so we're getting the error "called to undefined method "products". This way the field will check if the relationship exists before calling the method.