### PR TITLE
[8.x] Remove `cp_icon` config option

### DIFF
--- a/docs/control-panel.md
+++ b/docs/control-panel.md
@@ -23,23 +23,6 @@ Technically, you can’t fully disable Runway’s CP feature. However, what you 
 ],
 ```
 
-## Custom Icon for CP Nav Item
-
-Runway has a rather generic icon for resources in the Control Panel Nav. Feel free to change this to something else that better suits your use case (in fact, I’d encourage it).
-
-You can either provide the name of an existing icon [packaged into Statamic Core](https://github.com/statamic/cms/tree/3.1/resources/svg) or inline the SVG as a string.
-
-```php
-// config/runway.php
-
-'resources' => [
-	\App\Models\Order::class => [
-	    'name' => 'Orders',
-	    'cp_icon' => 'date',
-	],
-],
-```
-
 ## Permissions
 
 ![Screenshot of Runway's User Permissions](/img/runway/cp-user-permissions.png)

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -79,21 +79,6 @@ If you’d like to hide the CP Nav Item that’s registered for this model, just
 
 > Bear in mind, this will just hide the Nav Item for the CP interface, it won’t actually get rid of the routes being registered. If someone knows where to look, they could still use the CP to manage your models (they could guess the URL).
 
-### Control Panel Icon
-
-You should set `icon` to the name of the icon you’d like to use instead.
-
-Alternatively, if the icon you want isn’t [included in Statamic](https://github.com/statamic/cms/tree/3.1/resources/svg), you can also pass an inline SVG.
-
-```php
-'resources' => [
-	\App\Models\Order::class => [
-		'name' => 'Orders',
-        'cp_icon' => 'date',
-	],
-],
-```
-
 ### Route
 
 If you want to take advantage of Runway’s front-end routing abilities, you can pass in a `route` to enable it.

--- a/docs/upgrade-guides/v7-to-v8.md
+++ b/docs/upgrade-guides/v7-to-v8.md
@@ -66,6 +66,19 @@ To work around this, v8 introduces some changes around how nested fields are con
    
 As an upside of this new approach, nested fields can now be used with Runway's [GraphQL API](/graphql).
 
+### Removal of the `cp_icon` config option
+
+The `cp_icon` configuration option has been removed in Runway 8, in favour of being able to change the icon using Statamic's [Nav Preferences](https://statamic.dev/preferences#accessing-preferences) feature. 
+
+```php
+'resources' => [
+	\App\Models\Order::class => [
+		'name' => 'Orders',
+        'cp_icon' => 'date', // [tl! --]
+	],
+],
+```
+
 ## Previous upgrade guides
 
 -   [v3.x to v4.0](/upgrade-guides/v3-x-to-v4-0)

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -66,15 +66,6 @@ class Resource
         return $this->config;
     }
 
-    public function cpIcon(): string
-    {
-        if (! $this->config->has('cp_icon')) {
-            return File::get(__DIR__.'/../resources/svg/database.svg');
-        }
-
-        return $this->config->get('cp_icon');
-    }
-
     public function hidden(): bool
     {
         return $this->config->get('hidden', false);
@@ -290,7 +281,6 @@ class Resource
             'model' => $this->model(),
             'name' => $this->name(),
             'blueprint' => $this->blueprint(),
-            'cp_icon' => $this->cpIcon(),
             'hidden' => $this->hidden(),
             'route' => $this->route(),
             'has_publish_states' => $this->hasPublishStates(),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -142,7 +142,6 @@ class ServiceProvider extends AddonServiceProvider
                 ->each(function (Resource $resource) use (&$nav) {
                     $nav->create($resource->name())
                         ->section('Content')
-                        ->icon($resource->cpIcon())
                         ->route('runway.index', ['resource' => $resource->handle()])
                         ->can('view', $resource);
                 });


### PR DESCRIPTION
This pull request removes the `cp_icon` config option, in favour of customizing the icon via CP Nav Preferences (see https://github.com/statamic/cms/pull/8023).