### PR TITLE
[8.x] Fix attributes returning a collection instead of an array

### DIFF
--- a/src/Http/Controllers/CP/Traits/ExtractsFromModelFields.php
+++ b/src/Http/Controllers/CP/Traits/ExtractsFromModelFields.php
@@ -17,7 +17,7 @@ trait ExtractsFromModelFields
         $fields = $blueprint
             ->fields()
             ->setParent($model)
-            ->addValues($values->all())
+            ->addValues($values->toArray())
             ->preProcess();
 
         $values = $fields->values()->merge([


### PR DESCRIPTION
Following on from https://github.com/statamic/cms/issues/11333

Fix implemented through runway.