### PR TITLE
[8.x] Change `model_id` column on `runway_uris` table to a string

### DIFF
--- a/database/migrations/2021_05_04_162552_create_runway_uris_table.php
+++ b/database/migrations/2021_05_04_162552_create_runway_uris_table.php
@@ -17,7 +17,7 @@ class CreateRunwayUrisTable extends Migration
             $table->id();
             $table->string('uri');
             $table->string('model_type');
-            $table->bigInteger('model_id');
+            $table->string('model_id', 36);
             $table->timestamps();
         });
     }


### PR DESCRIPTION
This pull request updates the `runway_uris` migration stub, changing the `model_id` column from a `bigInteger` to a `string` in order to allow for models with UUIDs.