### PR TITLE
[7.x] Show status indicator on publish form

### DIFF
--- a/resources/js/components/resources/PublishForm.vue
+++ b/resources/js/components/resources/PublishForm.vue
@@ -4,7 +4,8 @@
 
         <div class="flex items-center mb-6">
             <h1 class="flex-1">
-                <div class="flex items-center">
+                <div class="flex items-baseline">
+                    <span v-if="! isCreating && resourced.has_publish_states" class="little-dot rtl:ml-2 ltr:mr-2 -top-1" :class="initialStatus" v-tooltip="__(initialStatus)" />
                     <span v-html="$options.filters.striptags(title)" />
                 </div>
             </h1>
@@ -244,6 +245,7 @@ export default {
         isCreating: Boolean,
         isInline: Boolean,
         initialReadOnly: Boolean,
+        initialStatus: Boolean,
         initialPermalink: String,
         revisionsEnabled: Boolean,
         canEditBlueprint: Boolean,

--- a/resources/js/components/resources/PublishForm.vue
+++ b/resources/js/components/resources/PublishForm.vue
@@ -5,7 +5,7 @@
         <div class="flex items-center mb-6">
             <h1 class="flex-1">
                 <div class="flex items-baseline">
-                    <span v-if="! isCreating && resourced.has_publish_states" class="little-dot rtl:ml-2 ltr:mr-2 -top-1" :class="initialStatus" v-tooltip="__(initialStatus)" />
+                    <span v-if="! isCreating && resource.has_publish_states" class="little-dot rtl:ml-2 ltr:mr-2 -top-1" :class="status" v-tooltip="__(status)" />
                     <span v-html="$options.filters.striptags(title)" />
                 </div>
             </h1>
@@ -245,7 +245,7 @@ export default {
         isCreating: Boolean,
         isInline: Boolean,
         initialReadOnly: Boolean,
-        initialStatus: Boolean,
+        initialStatus: String,
         initialPermalink: String,
         revisionsEnabled: Boolean,
         canEditBlueprint: Boolean,
@@ -262,6 +262,7 @@ export default {
             trackDirtyState: true,
             blueprint: this.initialBlueprint,
             title: this.initialTitle,
+            status: this.initialStatus,
             values: _.clone(this.initialValues),
             meta: _.clone(this.initialMeta),
             isWorkingCopy: this.initialIsWorkingCopy,
@@ -449,6 +450,7 @@ export default {
                     return this.$toast.error(__(`Couldn't save entry`));
                 }
                 this.title = response.data.data.title;
+                this.status = response.data.data.published;
                 this.isWorkingCopy = true;
                 if (!this.revisionsEnabled) this.permalink = response.data.data.permalink;
                 if (!this.isCreating) this.$toast.success(__('Saved'));

--- a/resources/js/components/resources/PublishForm.vue
+++ b/resources/js/components/resources/PublishForm.vue
@@ -501,6 +501,7 @@ export default {
                         this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 350);
 
                         if (this.publishStatesEnabled) {
+                            this.status = response.data.data.status;
                             this.initialPublished = response.data.data.published;
                         }
 

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -18,6 +18,7 @@
         initial-permalink="{{ $permalink }}"
         :initial-is-working-copy="{{ $str::bool($hasWorkingCopy) }}"
         :initial-read-only="{{ $str::bool($readOnly) }}"
+        :initial-status="{{ $str::bool($status) }}"
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
         :can-edit-blueprint="{{ Auth::user()->can('configure fields') ? 'true' : 'false' }}"
         :can-manage-publish-state="{{ $str::bool($canManagePublishState) }}"

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -18,7 +18,7 @@
         initial-permalink="{{ $permalink }}"
         :initial-is-working-copy="{{ $str::bool($hasWorkingCopy) }}"
         :initial-read-only="{{ $str::bool($readOnly) }}"
-        :initial-status="{{ $str::bool($status) }}"
+        initial-status="{{ $status }}"
         :breadcrumbs="{{ $breadcrumbs->toJson() }}"
         :can-edit-blueprint="{{ Auth::user()->can('configure fields') ? 'true' : 'false' }}"
         :can-manage-publish-state="{{ $str::bool($canManagePublishState) }}"

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -155,6 +155,7 @@ class ResourceController extends CpController
             'values' => $values,
             'meta' => $meta,
             'readOnly' => $resource->readOnly(),
+            'status' => $model->publishedStatus(),
             'permalink' => $resource->hasRouting() ? $model->uri() : null,
             'resourceHasRoutes' => $resource->hasRouting(),
             'currentModel' => [

--- a/src/Http/Resources/CP/Model.php
+++ b/src/Http/Resources/CP/Model.php
@@ -15,7 +15,8 @@ class Model extends JsonResource
             'reference' => $this->resource->reference(),
             'title' => $this->resource->{$runwayResource->titleField()},
             'permalink' => $runwayResource->hasRouting() ? $this->resource->absoluteUrl() : null,
-            'published' => $this->resource->publishedStatus(),
+            'status' => $this->resource->publishedStatus(),
+            'published' => $this->resource->published(),
             'edit_url' => $this->resource->runwayEditUrl(),
             'resource' => [
                 'handle' => $runwayResource->handle(),


### PR DESCRIPTION
This pull request adds a status indicator next to titles on model publish forms, similar to how they're displayed on entries:

![CleanShot 2025-02-07 at 15 24 05](https://github.com/user-attachments/assets/e39b13ef-fa9d-42f5-97bb-29e7c0cd1816)
