### PR TITLE
[8.x] Improve compatibility with per model database connections

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -4,7 +4,6 @@ namespace StatamicRadPack\Runway;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Search;
@@ -246,7 +245,7 @@ class Resource
     public function databaseColumns(): array
     {
         return Blink::once('runway-database-columns-'.$this->databaseTable(), function () {
-            return Schema::getColumnListing($this->databaseTable());
+            return $this->model()->getConnection()->getSchemaBuilder()->getColumnListing($this->databaseTable());
         });
     }
 


### PR DESCRIPTION
Currently the resource gathers the columns using the Schema facade, but this facade defaults to the default database connection for the entire project.

This can lead to problems where you need to specify the connection on a per model basis - like when using the Orbit driver - https://github.com/ryangjchandler/orbit

This PR resolves this by getting columns from schema builder on the model's connection.
Everything should work just the same.  :)