### PR TITLE
[8.x] Add withoutGlobalScopes to Rebuild URI's command

### DIFF
--- a/src/Console/Commands/RebuildUriCache.php
+++ b/src/Console/Commands/RebuildUriCache.php
@@ -69,7 +69,7 @@ class RebuildUriCache extends Command
                     return;
                 }
 
-                $query = $resource->model()->newQuery();
+                $query = $resource->model()->newQuery()->withoutGlobalScopes();
                 $query->when($query->hasNamedScope('runwayRoutes'), fn ($query) => $query->runwayRoutes());
 
                 if (! $query->exists()) {


### PR DESCRIPTION
Currently, models that have global model scope(s) set up (such as for private or hidden models) won't have their URI rebuilt/cached when this command is run.

This PR adds a simple `->withoutGlobalScopes()` to bypass the scopes while the cache is being rebuilt.

I don't think there are any long term implications against this, but let me know if there are.  Could also just place it behind an option flag if so.