### PR TITLE
[8.x] Fix disappearing status filter on collections 

### DIFF
--- a/src/Scopes/Status.php
+++ b/src/Scopes/Status.php
@@ -9,6 +9,8 @@ use StatamicRadPack\Runway\Runway;
 
 class Status extends BaseStatusFilter
 {
+    protected static $handle = 'runway-status';
+
     public function visibleTo($key): bool
     {
         return in_array($key, ['runway']) && $this->resource()->hasPublishStates();


### PR DESCRIPTION
This pull request fixes an issue where Runway would override the "Status" filter from Statamic, preventing it from showing on collection listings.

Fixes #662.