### PR TITLE
[8.x] Supports Laravel 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "require": {
         "php": "^8.2",
         "ajthinking/archetype": "^1.0.3 || ^2.0",
-        "laravel/framework": "^10.25.0 || ^11.3",
+        "laravel/framework": "^10.25.0 || ^11.3 || ^12.0",
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/ignition": "^1.15",
         "spatie/invade": "^2.1",
@@ -51,8 +51,8 @@
     "require-dev": {
         "laravel/pint": "^1.0",
         "spatie/test-time": "^1.2",
-        "orchestra/testbench": "^8.28 || ^9.6.1",
-        "phpunit/phpunit": "^10.5.35"
+        "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
+        "phpunit/phpunit": "^10.5.35 || ^11.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -63,5 +63,5 @@
             "composer/package-versions-deprecated": true
         }
     },
-    "minimum-stability": "alpha"
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
This pull request adds Laravel 12 support to `statamic-rad-pack/runway`.

Depends on:

* [ ] https://github.com/Stillat/proteus/pull/34