### PR TITLE
[8.x] Revert "[8.x] Fix attributes returning a collection instead of an array"

### DIFF
--- a/src/Http/Controllers/CP/Traits/ExtractsFromModelFields.php
+++ b/src/Http/Controllers/CP/Traits/ExtractsFromModelFields.php
@@ -17,7 +17,7 @@ trait ExtractsFromModelFields
         $fields = $blueprint
             ->fields()
             ->setParent($model)
-            ->addValues($values->toArray())
+            ->addValues($values->all())
             ->preProcess();
 
         $values = $fields->values()->merge([


### PR DESCRIPTION
This pull request reverts #654 as it caused issues with relationship fields for some projects. The original issue that PR tried to solve can be fixed by using a different cast on the Eloquent model.

Fixes #665.