### PR TITLE
[8.x] Add `runway` query scope

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -236,6 +236,44 @@ public function visibleTo($item)
 }
 ```
 
+## Queries
+
+Every query made by Runway to your model will call the `runway` query scope. This allows you to easily filter the models returned by Runway.
+
+```php
+class YourModel extends Model
+{
+	public function scopeRunway($query)
+	{
+		return $query->where('something', true);
+	}
+}
+```
+
+If you only want to filter models returned in the Control Panel, see the `runwayListing` and `runwaySearch` scopes documented on the [Control Panel](/control-panel#content-scoping-control-panel-results) page.
+
+### Disabling global scopes
+
+By default, Runway will observe all global scopes registered on your model. However, this might not be ideal if you want to access, for example, soft deleted models in Runway.
+
+You can work around this by calling the `withoutGlobalScopes` method in the `runway` query scope:
+
+```php
+class YourModel extends Model
+{
+	public function scopeRunway($query)
+	{
+	    // Disables ALL global scopes
+		return $query->->withoutGlobalScopes();
+		
+		// Disables a specific global scope
+		return $query->withoutGlobalScope([ActiveScope::class]);
+	}
+}
+```
+
+You can find more information about global scopes on the [Laravel documentation](https://laravel.com/docs/12.x/eloquent#removing-global-scopes).
+
 ## List of Resources
 
 If you're unsure about the handle of a resource, you may want to check it. You may do so with the `php please runway:resources` command which will display a list of Runway Resources.

--- a/src/Console/Commands/RebuildUriCache.php
+++ b/src/Console/Commands/RebuildUriCache.php
@@ -69,7 +69,7 @@ class RebuildUriCache extends Command
                     return;
                 }
 
-                $query = $resource->model()->newQuery()->withoutGlobalScopes();
+                $query = $resource->newEloquentQuery()->withoutGlobalScopes();
                 $query->when($query->hasNamedScope('runwayRoutes'), fn ($query) => $query->runwayRoutes());
 
                 if (! $query->exists()) {

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -152,7 +152,7 @@ abstract class BaseFieldtype extends Relationship
     {
         $resource = Runway::findResource($this->config('resource'));
 
-        $query = $resource->model()->newQuery();
+        $query = $resource->newEloquentQuery();
 
         $query->when($query->hasNamedScope('runwayListing'), fn ($query) => $query->runwayListing());
 

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -38,9 +38,7 @@ class ResourceIndexQuery extends Query
 
     public function resolve($root, $args)
     {
-        $query = $this->resource->model()
-            ->newQuery()
-            ->with($this->resource->eagerLoadingRelationships());
+        $query = $this->resource->newEloquentQuery()->with($this->resource->eagerLoadingRelationships());
 
         $this->filterQuery($query, $args['filter'] ?? []);
         $this->sortQuery($query, $args['sort'] ?? []);

--- a/src/Http/Controllers/CP/ModelRevisionsController.php
+++ b/src/Http/Controllers/CP/ModelRevisionsController.php
@@ -14,7 +14,7 @@ class ModelRevisionsController extends CpController
 
     public function index(Request $request, Resource $resource, $model)
     {
-        $model = $resource->model()
+        $model = $resource->newEloquentQuery()
             ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
             ->first();
 
@@ -43,7 +43,7 @@ class ModelRevisionsController extends CpController
 
     public function store(Request $request, Resource $resource, $model)
     {
-        $model = $resource->model()
+        $model = $resource->newEloquentQuery()
             ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
             ->first();
 
@@ -57,7 +57,7 @@ class ModelRevisionsController extends CpController
 
     public function show(Request $request, Resource $resource, $model, $revisionId)
     {
-        $model = $resource->model()
+        $model = $resource->newEloquentQuery()
             ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
             ->first();
 

--- a/src/Http/Controllers/CP/PublishedModelsController.php
+++ b/src/Http/Controllers/CP/PublishedModelsController.php
@@ -14,7 +14,7 @@ class PublishedModelsController extends CpController
 
     public function store(Request $request, Resource $resource, $model)
     {
-        $model = $resource->model()
+        $model = $resource->newEloquentQuery()
             ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
             ->first();
 
@@ -36,7 +36,7 @@ class PublishedModelsController extends CpController
 
     public function destroy(Request $request, Resource $resource, $model)
     {
-        $model = $resource->model()
+        $model = $resource->newEloquentQuery()
             ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
             ->first();
 

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -119,7 +119,7 @@ class ResourceController extends CpController
 
     public function edit(EditRequest $request, Resource $resource, $model)
     {
-        $model = $resource->model()->where($resource->model()->qualifyColumn($resource->routeKey()), $model)->first();
+        $model = $resource->newEloquentQuery()->firstWhere($resource->model()->qualifyColumn($resource->routeKey()), $model);
 
         if (! $model) {
             throw new NotFoundHttpException;
@@ -181,7 +181,7 @@ class ResourceController extends CpController
     {
         $resource->blueprint()->fields()->setParent($model)->addValues($request->all())->validator()->validate();
 
-        $model = $resource->model()->where($resource->model()->qualifyColumn($resource->routeKey()), $model)->first();
+        $model = $resource->newEloquentQuery()->firstWhere($resource->model()->qualifyColumn($resource->routeKey()), $model);
         $model = $model->fromWorkingCopy();
 
         $this->prepareModelForSaving($resource, $model, $request);

--- a/src/Http/Controllers/CP/ResourceListingController.php
+++ b/src/Http/Controllers/CP/ResourceListingController.php
@@ -23,7 +23,7 @@ class ResourceListingController extends CpController
             abort(403);
         }
 
-        $query = $resource->model()->with($resource->eagerLoadingRelationships());
+        $query = $resource->newEloquentQuery()->with($resource->eagerLoadingRelationships());
 
         $query->when($query->hasNamedScope('runwayListing'), fn ($query) => $query->runwayListing());
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -31,6 +32,11 @@ class Resource
     public function model(): Model
     {
         return $this->model;
+    }
+
+    public function newEloquentQuery(): Builder
+    {
+        return $this->model->newQuery()->runway();
     }
 
     public function name()

--- a/src/Routing/RunwayUri.php
+++ b/src/Routing/RunwayUri.php
@@ -11,7 +11,7 @@ class RunwayUri extends Model
 
     public function model(): MorphTo
     {
-        return $this->morphTo();
+        return $this->morphTo()->runway();
     }
 
     public function getTable()

--- a/src/Search/Provider.php
+++ b/src/Search/Provider.php
@@ -19,8 +19,7 @@ class Provider extends BaseProvider
 
         return collect($resources)->flatMap(function ($handle) {
             return Runway::findResource($handle)
-                ->model()
-                ->query()
+                ->newEloquentQuery()
                 ->whereStatus('published')
                 ->get()
                 ->mapInto(Searchable::class);

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -48,7 +48,7 @@ class RunwayTag extends Tags
 
     protected function query(): Builder
     {
-        $query = $this->resource->model()->query()
+        $query = $this->resource->query()
             ->when(
                 $this->params->get('status'),
                 fn ($query, $status) => $query->whereStatus($status),

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -49,6 +49,11 @@ trait HasRunwayResource
         return "runway::{$this->runwayResource()->handle()}::{$this->getKey()}";
     }
 
+    public function scopeRunway(Builder $query)
+    {
+        return $query;
+    }
+
     public function scopeRunwaySearch(Builder $query, string $searchQuery)
     {
         $this->runwayResource()->blueprint()->fields()->all()


### PR DESCRIPTION
This pull request implements a `runway` query scope, which allows developers to customise the queries executed by Runway.

For example: maybe you want to disable global scopes, or only return models created in the past year.

```php
class YourModel extends Model
{
	public function scopeRunway($query)
	{
		return $query->where('something', true);
	}
}
``` 

Under the hood, all query now go through the `Resource::newEloquentQuery()` method.

Related: #669