### PR TITLE
[8.x] Fix typo in resources.md

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -264,7 +264,7 @@ class YourModel extends Model
 	public function scopeRunway($query)
 	{
 	    // Disables ALL global scopes
-		return $query->->withoutGlobalScopes();
+		return $query->withoutGlobalScopes();
 		
 		// Disables a specific global scope
 		return $query->withoutGlobalScope([ActiveScope::class]);


### PR DESCRIPTION
Removes extra "->" in Disabling global scopes example