### PR TITLE
[8.x] Only add `getRouteKeyName` to models when collection uses slugs

### DIFF
--- a/src/Console/Commands/ImportCollection.php
+++ b/src/Console/Commands/ImportCollection.php
@@ -162,6 +162,16 @@ class ImportCollection extends Command
                 ->filter(fn ($column) => in_array($column['type'], ['json', 'boolean', 'datetime', 'date', 'time', 'float', 'integer']))
                 ->map(fn ($column) => "            '{$column['name']}' => '{$column['type']}',")
                 ->join(PHP_EOL))
+            ->when($this->collection->requiresSlugs(), function ($str) {
+                return $str->replaceLast('}', <<<'PHP'
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+}
+PHP);
+            })
             ->__toString();
 
         File::put(app_path("Models/{$this->modelName}.php"), $modelContents);

--- a/src/Console/Commands/stubs/model-l10.stub
+++ b/src/Console/Commands/stubs/model-l10.stub
@@ -31,9 +31,4 @@ class {{ class }} extends Model
     protected $casts = [
 {{ casts }}
     ];
-
-    public function getRouteKeyName(): string
-    {
-        return 'slug';
-    }
 }

--- a/src/Console/Commands/stubs/model.stub
+++ b/src/Console/Commands/stubs/model.stub
@@ -34,9 +34,4 @@ class {{ class }} extends Model
 {{ casts }}
         ];
     }
-
-    public function getRouteKeyName(): string
-    {
-        return 'slug';
-    }
 }


### PR DESCRIPTION
This pull request fixes an issue with the collection importer, where the `getRouteKeyName` method would be added to Eloquent models, even when the slugs weren't enabled on the source collection.

This would cause a 404 when viewing models in the Control Panel.
 
Related: https://github.com/statamic-rad-pack/runway/discussions/675#discussioncomment-12664400