### PR TITLE
[8.x] Fix error when serializing resources with appended attributes

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -282,7 +282,7 @@ class Resource
     {
         return [
             'handle' => $this->handle(),
-            'model' => $this->model(),
+            'model' => get_class($this->model()),
             'name' => $this->name(),
             'blueprint' => $this->blueprint(),
             'hidden' => $this->hidden(),


### PR DESCRIPTION
This pull request fixes an error when attempting to serialize Runway's `Resource` object, which ultimately attempts to serialize a fresh instance of the Eloquent model.

However, since it serialises the fresh instance of the Eloquent model, no attributes are set, so model accessors using the `$attributes` parameter error out:

```php
// app/Models/User.php

protected $appends = ['thingy'];

protected function thingy(): Attribute
{
    return Attribute::make(
        get: fn (mixed $value, array $attributes) => $attributes['name']
    );
}
```

```php
use App\Models\User;

(new User)->toArray();
```

```
Undefined array key "name"
```

To prevent an error when serializing appended attributes on a fresh model, we're now simply returning the model's class name, rather than calling its `toArray()` method.

Fixes #685.