### PR TITLE
[8.x] Require `spatie/laravel-ray` in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,9 +50,10 @@
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "spatie/test-time": "^1.2",
         "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
-        "phpunit/phpunit": "^10.5.35 || ^11.0"
+        "phpunit/phpunit": "^10.5.35 || ^11.0",
+        "spatie/laravel-ray": "^1.40",
+        "spatie/test-time": "^1.2"
     },
     "config": {
         "optimize-autoloader": true,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -53,4 +53,12 @@ abstract class TestCase extends AddonTestCase
             Blueprint::setDirectory(__DIR__.'/__fixtures__/resources/blueprints');
         });
     }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            ...parent::getPackageProviders($app),
+            \Spatie\LaravelRay\RayServiceProvider::class,
+        ];
+    }
 }


### PR DESCRIPTION
This pull request requires `spatie/laravel-ray` so we can use Ray during development, without needing to require it globally.