### PR TITLE
[8.x] Use `runway` query scope when fetching related models

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -337,7 +337,7 @@ abstract class BaseFieldtype extends Relationship
     protected function toItemArray($id)
     {
         $resource = Runway::findResource($this->config('resource'));
-        $model = $id instanceof Model ? $id : $resource->model()->firstWhere($resource->primaryKey(), $id);
+        $model = $id instanceof Model ? $id : $resource->model()->runway()->firstWhere($resource->primaryKey(), $id);
 
         if (! $model) {
             return $this->invalidItemArray($id);

--- a/src/Http/Controllers/CP/ResourceListingController.php
+++ b/src/Http/Controllers/CP/ResourceListingController.php
@@ -23,7 +23,7 @@ class ResourceListingController extends CpController
             abort(403);
         }
 
-        $query = $resource->newEloquentQuery()->with($resource->eagerLoadingRelationships());
+        $query = $resource->newEloquentQueryBuilderWithEagerLoadedRelationships();
 
         $query->when($query->hasNamedScope('runwayListing'), fn ($query) => $query->runwayListing());
 

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -69,7 +69,9 @@ trait PreparesModels
                 }
 
                 if ($field->fieldtype() instanceof HasManyFieldtype) {
-                    $value = data_get($model, $resource->eloquentRelationships()->get($field->handle()));
+                    $value = $model->{$resource->eloquentRelationships()->get($field->handle())}()
+                        ->runway()
+                        ->get();
 
                     // Use IDs from the model's $runwayRelationships property, if there are any.
                     if (array_key_exists($field->handle(), $model->runwayRelationships)) {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -39,6 +39,23 @@ class Resource
         return $this->model->newQuery()->runway();
     }
 
+    public function newEloquentQueryBuilderWithEagerLoadedRelationships(): Builder
+    {
+        return $this
+            ->newEloquentQuery()
+            ->with(
+                collect($this->eagerLoadingRelationships())
+                    ->mapWithKeys(function (string $relationship): array {
+                        if ($relationship === 'runwayUri') {
+                            return [$relationship => fn ($query) => null];
+                        }
+
+                        return [$relationship => fn ($query) => $query->runway()];
+                    })
+                    ->all()
+            );
+    }
+
     public function name()
     {
         return $this->name;


### PR DESCRIPTION
This pull request fixes an issue where the `runway` query scope added in #671 wasn't being used when fetching related models in the Control Panel.