### PR TITLE
[8.x] Prevent errors from PostgreSQL when querying `runway_uris` table

### DIFF
--- a/src/Routing/MorphOneWithStringKey.php
+++ b/src/Routing/MorphOneWithStringKey.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace StatamicRadPack\Runway\Routing;
+
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+class MorphOneWithStringKey extends MorphOne
+{
+    public function addConstraints()
+    {
+        if (static::$constraints) {
+            $this->getQuery()->where($this->morphType, $this->morphClass)
+                ->where($this->foreignKey, (string) $this->getParentKey());
+        }
+    }
+
+    public function addEagerConstraints(array $models)
+    {
+        $keys = array_map('strval', $this->getKeys($models, $this->localKey));
+
+        $this->getQuery()->where($this->morphType, $this->morphClass)
+            ->whereIn($this->foreignKey, $keys);
+    }
+}

--- a/src/Routing/Traits/RunwayRoutes.php
+++ b/src/Routing/Traits/RunwayRoutes.php
@@ -2,15 +2,14 @@
 
 namespace StatamicRadPack\Runway\Routing\Traits;
 
-use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Support\Str;
 use Statamic\Facades\Antlers;
 use Statamic\StaticCaching\Cacher;
 use Statamic\Support\Arr;
+use StatamicRadPack\Runway\Routing\MorphOneWithStringKey;
 use StatamicRadPack\Runway\Routing\Routable;
 use StatamicRadPack\Runway\Routing\RoutingModel;
 use StatamicRadPack\Runway\Routing\RunwayUri;
-use StatamicRadPack\Runway\Routing\MorphOneWithStringKey;
 use StatamicRadPack\Runway\Runway;
 
 trait RunwayRoutes

--- a/src/Routing/Traits/RunwayRoutes.php
+++ b/src/Routing/Traits/RunwayRoutes.php
@@ -10,6 +10,7 @@ use Statamic\Support\Arr;
 use StatamicRadPack\Runway\Routing\Routable;
 use StatamicRadPack\Runway\Routing\RoutingModel;
 use StatamicRadPack\Runway\Routing\RunwayUri;
+use StatamicRadPack\Runway\Routing\MorphOneWithStringKey;
 use StatamicRadPack\Runway\Runway;
 
 trait RunwayRoutes
@@ -66,9 +67,9 @@ trait RunwayRoutes
         return $this->routingModel()->getRouteKey();
     }
 
-    public function runwayUri(): MorphOne
+    public function runwayUri(): MorphOneWithStringKey
     {
-        return $this->morphOne(RunwayUri::class, 'model');
+        return new MorphOneWithStringKey(RunwayUri::query(), $this, 'model_type', 'model_id', $this->getKeyName());
     }
 
     public static function bootRunwayRoutes()


### PR DESCRIPTION
While I was working on the collection importer command, I changed the `model_id` column on the `runway_uris` table from an integer to a string (see #656), allowing imported models to keep their original, string-based UUIDs, preventing broken relationships.

This change worked fine for my locally, as MySQL would cast integers to strings when querying, and vice-versa.

However, this change caused issues with PostgreSQL, which errors when you try and query a string column with an integer:

```
PDOException: SQLSTATE[42883]: Undefined function: 7 ERROR:  operator does not exist: character varying = integer
LINE 1: ...from "runway_uris" where "runway_uris"."model_id" in (1, 3, ...
                                                             ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
```

After trying a couple of things, I ended up resolving the issue by overriding Laravel's `MorphOne` relationship class and tweaking the query.

This solution seems to work on both MySQL and PostgreSQL. 🎉

Fixes #689.