### PR TITLE
[8.x] Collection Importer fixes

### DIFF
--- a/src/Console/Commands/ImportCollection.php
+++ b/src/Console/Commands/ImportCollection.php
@@ -190,7 +190,10 @@ PHP);
                 'name' => $this->collection->title(),
                 'published' => true,
                 'revisions' => $this->collection->revisionsEnabled(),
-                'route' => $this->collection->route(Facades\Site::default()->handle()),
+                'route' => Str::of($this->collection->route(Facades\Site::default()->handle()))
+                    ->replace('{parent_uri}/', '')
+                    ->replace('{slug}', '{{ slug }}')
+                    ->__toString(),
                 'template' => $this->collection->template(),
                 'layout' => $this->collection->layout(),
                 'order_by' => $this->collection->sortField(),

--- a/src/Console/Commands/ImportCollection.php
+++ b/src/Console/Commands/ImportCollection.php
@@ -302,10 +302,12 @@ PHP);
                     ->merge([
                         'uuid' => $entry->id(),
                         'slug' => $entry->slug(),
-                        'date' => $entry->date(),
                         'published' => $entry->published(),
                         'updated_at' => $entry->get('updated_at') ?? now(),
                     ])
+                    ->when($entry->hasDate(), fn ($attributes) => $attributes->merge([
+                        'date' => $entry->date(),
+                    ]))
                     ->all();
 
                 $model = $model::find($entry->id()) ?? (new $model);

--- a/src/Console/Commands/ImportCollection.php
+++ b/src/Console/Commands/ImportCollection.php
@@ -260,6 +260,10 @@ PHP);
                     $string = "{$string}->default({$default})";
                 }
 
+                if (isset($column['primary'])) {
+                    $string = "{$string}->primary()";
+                }
+
                 return "            {$string};";
             })->implode(PHP_EOL))
             ->__toString();
@@ -326,7 +330,7 @@ PHP);
                     'nullable' => ! $field->isRequired(),
                 ];
             })
-            ->prepend(['type' => 'uuid'])
+            ->prepend(['type' => 'string', 'name' => 'uuid', 'primary' => true])
             ->push(['type' => 'boolean', 'name' => 'published', 'default' => false])
             ->push(['type' => 'timestamps'])
             ->values()


### PR DESCRIPTION
This pull request fixes various issues with the `runway:import-collection` command. 

Changes:

* The collection route is now formatted before being written to the Runway config.
* The `uuid` column is now a `string`, rather than a true `uuid` to account for entries with non-UUID IDs.
    * For example: when you setup a new Statamic site, the [ID of the home entry](https://github.com/statamic/statamic/blob/5.x/content/collections/pages/home.md?plain=1#L3) will be `home`, rather than an actual UUID.
* Fixed an issue where it would attempt to save the `date` column, even if the entry's collection wasn't dated.