### PR TITLE
Improve nested field augmentation

### DIFF
--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -45,7 +45,7 @@ class AugmentedModelTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_nested_values()
+    public function it_gets_nested_values_via_nested_field_prefix()
     {
         $post = Post::factory()->create([
             'values' => [
@@ -58,8 +58,28 @@ class AugmentedModelTest extends TestCase
 
         $this->assertIsArray($augmented->get('values')->value());
 
+        // Eg. values:alt_title, values:alt_body
         $this->assertEquals('Alternative Title...', $augmented->get('values')->value()['alt_title']->value());
         $this->assertEquals('<p>This is a <strong>great</strong> post! You should <em>read</em> it.</p>', trim($augmented->get('values')->value()['alt_body']->value()));
+    }
+
+    #[Test]
+    public function it_gets_nested_values_via_nested_field_handles()
+    {
+        $post = Post::factory()->create([
+            'values' => [
+                'alt_title' => 'Alternative Title...',
+                'alt_body' => 'This is a **great** post! You should *read* it.',
+            ],
+        ]);
+
+        $augmented = new AugmentedModel($post);
+
+        $this->assertIsArray($augmented->get('values')->value());
+
+        // Eg. values_alt_title, values_alt_body
+        $this->assertEquals('Alternative Title...', $augmented->get('values_alt_title')->value());
+        $this->assertEquals('<p>This is a <strong>great</strong> post! You should <em>read</em> it.</p>', trim($augmented->get('values_alt_body')->value()));
     }
 
     #[Test]

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -64,7 +64,7 @@ class AugmentedModelTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_nested_values_via_nested_field_handles()
+    public function it_gets_nested_values_via_nested_field_handle()
     {
         $post = Post::factory()->create([
             'values' => [


### PR DESCRIPTION
Currently, if you want to access a nested field on an augmented model, you need to go through the JSON column, like this:

```antlers
{{ meta:rating }}
```

This pull request makes it possible to also access nested fields using their field handles:

```antlers
{{ meta_rating }}
```

Closes #698