### PR TITLE
[8.x] Allow programmatic registration of resources

### DIFF
--- a/src/Runway.php
+++ b/src/Runway.php
@@ -14,27 +14,20 @@ class Runway
 
     public static function discoverResources(): self
     {
-        static::$resources = collect(config('runway.resources'))
+        static::$resources = array_merge(static::$resources, collect(config('runway.resources'))
             ->mapWithKeys(function ($config, $model) {
-                $config = collect($config);
-                $handle = $config->get('handle', Str::snake(class_basename($model)));
+                $resource = static::buildResource($model, $config);
+                $handle = $resource->handle();
 
-                throw_if(
-                    ! in_array(Traits\HasRunwayResource::class, class_uses_recursive($model)),
-                    new TraitMissingException($model),
-                );
-
-                $resource = new Resource(
-                    handle: $handle,
-                    model: $model instanceof Model ? $model : new $model,
-                    name: $config['name'] ?? Str::title($handle),
-                    config: $config,
-                );
+                if (isset(static::$resources[$handle])) {
+                    throw new \InvalidArgumentException("Resource with handle {$resource->handle()} already registered");
+                }
 
                 return [$handle => $resource];
             })
             ->filter()
-            ->toArray();
+            ->toArray()
+        );
 
         return new static;
     }
@@ -62,6 +55,40 @@ class Runway
         if (! $resource) {
             throw new ResourceNotFound($model::class);
         }
+
+        return $resource;
+    }
+
+    public static function registerResource(string $model, array $config): self
+    {
+        $resource = static::buildResource($model, $config);
+        if (isset(static::$resources[$resource->handle()])) {
+            throw new \InvalidArgumentException("Resource with handle {$resource->handle()} already registered");
+        }
+        static::$resources[$resource->handle()] = $resource;
+
+        return new static;
+    }
+
+    /**
+     * @throws TraitMissingException
+     */
+    private static function buildResource(string $model, array $config): Resource
+    {
+        $config = collect($config);
+        $handle = $config->get('handle', Str::snake(class_basename($model)));
+
+        throw_if(
+            ! in_array(Traits\HasRunwayResource::class, class_uses_recursive($model)),
+            new TraitMissingException($model),
+        );
+
+        $resource = new Resource(
+            handle: $handle,
+            model: $model instanceof Model ? $model : new $model,
+            name: $config['name'] ?? Str::title($handle),
+            config: $config,
+        );
 
         return $resource;
     }

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -93,6 +93,11 @@ class Runway
         return $resource;
     }
 
+    public static function resetResources(): void
+    {
+        self::$resources = [];
+    }
+
     public static function usesRouting(): bool
     {
         return static::allResources()->filter->hasRouting()->count() >= 1;

--- a/tests/Actions/DeleteModelTest.php
+++ b/tests/Actions/DeleteModelTest.php
@@ -36,6 +36,7 @@ class DeleteModelTest extends TestCase
     #[Test]
     public function is_not_visible_to_eloquent_model_when_resource_is_read_only()
     {
+        Runway::resetResources();
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.read_only', true);
         Runway::discoverResources();
 

--- a/tests/Actions/DuplicateModelTest.php
+++ b/tests/Actions/DuplicateModelTest.php
@@ -37,6 +37,8 @@ class DuplicateModelTest extends TestCase
     #[Test]
     public function is_not_visible_to_eloquent_model_when_resource_is_read_only()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.read_only', true);
 
         Runway::discoverResources();

--- a/tests/Actions/PublishTest.php
+++ b/tests/Actions/PublishTest.php
@@ -43,6 +43,7 @@ class PublishTest extends TestCase
     #[Test]
     public function is_not_visible_to_eloquent_model_when_resource_is_read_only()
     {
+        Runway::resetResources();
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.read_only', true);
         Runway::discoverResources();
 

--- a/tests/Actions/UnpublishTest.php
+++ b/tests/Actions/UnpublishTest.php
@@ -43,6 +43,7 @@ class UnpublishTest extends TestCase
     #[Test]
     public function is_not_visible_to_eloquent_model_when_resource_is_read_only()
     {
+        Runway::resetResources();
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.read_only', true);
         Runway::discoverResources();
 

--- a/tests/Console/Commands/ListResourcesTest.php
+++ b/tests/Console/Commands/ListResourcesTest.php
@@ -28,6 +28,7 @@ class ListResourcesTest extends TestCase
     #[Test]
     public function it_outputs_error_when_no_resources_exist()
     {
+        Runway::resetResources();
         Config::set('runway.resources', []);
         Runway::discoverResources();
 

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -174,6 +174,8 @@ class BelongsToFieldtypeTest extends TestCase
     #[Test]
     public function can_get_index_items_and_search_using_a_search_index()
     {
+        Runway::resetResources();
+
         Config::set('statamic.search.indexes.test_search_index', [
             'driver' => 'local',
             'searchables' => ['runway:author'],

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -136,6 +136,8 @@ class HasManyFieldtypeTest extends TestCase
     #[Test]
     public function can_get_index_items_in_order_specified_in_runway_config()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.order_by', 'title');
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.order_by_direction', 'asc');
 
@@ -219,6 +221,8 @@ class HasManyFieldtypeTest extends TestCase
     #[Test]
     public function can_get_index_items_and_search_using_a_search_index()
     {
+        Runway::resetResources();
+
         Config::set('statamic.search.indexes.test_search_index', [
             'driver' => 'local',
             'searchables' => ['runway:post'],

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -48,6 +48,8 @@ class ResourceControllerTest extends TestCase
     #[Test]
     public function cant_create_resource_if_resource_is_read_only()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.'.Post::class.'.read_only', true);
 
         Runway::discoverResources();
@@ -103,6 +105,8 @@ class ResourceControllerTest extends TestCase
     #[Test]
     public function cant_store_resource_if_resource_is_read_only()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.'.Post::class.'.read_only', true);
 
         Runway::discoverResources();
@@ -445,6 +449,8 @@ class ResourceControllerTest extends TestCase
     #[Test]
     public function can_edit_resource_if_resource_is_read_only()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.'.Post::class.'.read_only', true);
 
         Runway::discoverResources();
@@ -533,6 +539,8 @@ class ResourceControllerTest extends TestCase
     #[Test]
     public function cant_update_resource_if_resource_is_read_only()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.'.Post::class.'.read_only', true);
 
         Runway::discoverResources();

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -55,6 +55,8 @@ class ResourceListingControllerTest extends TestCase
     #[Test]
     public function listing_rows_are_ordered_as_per_config()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.order_by', 'id');
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.order_by_direction', 'desc');
 
@@ -245,6 +247,8 @@ class ResourceListingControllerTest extends TestCase
     #[Test]
     public function can_search_using_a_search_index()
     {
+        Runway::resetResources();
+
         Config::set('statamic.search.indexes.test_search_index', [
             'driver' => 'local',
             'searchables' => ['runway:post'],

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -13,8 +13,6 @@ class ResourceTest extends TestCase
     #[Test]
     public function can_get_eloquent_relationships_for_belongs_to_field()
     {
-        Runway::discoverResources();
-
         $resource = Runway::findResource('post');
 
         $eloquentRelationships = $resource->eloquentRelationships();
@@ -46,8 +44,6 @@ class ResourceTest extends TestCase
     #[Test]
     public function can_get_eloquent_relationships_for_runway_uri_routing()
     {
-        Runway::discoverResources();
-
         $resource = Runway::findResource('post');
 
         $eloquentRelationships = $resource->eloquentRelationships();
@@ -58,8 +54,6 @@ class ResourceTest extends TestCase
     #[Test]
     public function can_get_eager_loading_relationships()
     {
-        Runway::discoverResources();
-
         $resource = Runway::findResource('post');
 
         $eagerLoadingRelationships = $resource->eagerLoadingRelationships();
@@ -73,6 +67,8 @@ class ResourceTest extends TestCase
     #[Test]
     public function can_get_eager_loading_relationships_from_config()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.with', [
             'author',
         ]);
@@ -91,6 +87,8 @@ class ResourceTest extends TestCase
     #[Test]
     public function can_get_generated_singular()
     {
+        Runway::resetResources();
+
         Runway::discoverResources();
 
         $resource = Runway::findResource('post');
@@ -103,6 +101,8 @@ class ResourceTest extends TestCase
     #[Test]
     public function can_get_configured_singular()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.singular', 'Bibliothek');
 
         Runway::discoverResources();
@@ -117,8 +117,6 @@ class ResourceTest extends TestCase
     #[Test]
     public function can_get_generated_plural()
     {
-        Runway::discoverResources();
-
         $resource = Runway::findResource('post');
 
         $plural = $resource->plural();
@@ -129,6 +127,8 @@ class ResourceTest extends TestCase
     #[Test]
     public function can_get_configured_plural()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.plural', 'Bibliotheken');
 
         Runway::discoverResources();
@@ -213,6 +213,8 @@ class ResourceTest extends TestCase
     #[Test]
     public function can_get_title_field()
     {
+        Runway::resetResources();
+
         $blueprint = Blueprint::make()->setContents([
             'tabs' => [
                 'main' => [
@@ -241,6 +243,8 @@ class ResourceTest extends TestCase
     #[Test]
     public function revisions_can_be_enabled()
     {
+        Runway::resetResources();
+
         Config::set('statamic.editions.pro', true);
         Config::set('statamic.revisions.enabled', true);
 
@@ -257,6 +261,8 @@ class ResourceTest extends TestCase
     #[Test]
     public function revisions_cant_be_enabled_without_revisions_being_enabled_globally()
     {
+        Runway::resetResources();
+
         Config::set('statamic.editions.pro', true);
         Config::set('statamic.revisions.enabled', false);
 
@@ -273,6 +279,8 @@ class ResourceTest extends TestCase
     #[Test]
     public function revisions_cant_be_enabled_without_statamic_pro()
     {
+        Runway::resetResources();
+
         Config::set('statamic.editions.pro', false);
         Config::set('statamic.revisions.enabled', true);
 
@@ -289,6 +297,8 @@ class ResourceTest extends TestCase
     #[Test]
     public function revisions_cant_be_enabled_without_publish_states()
     {
+        Runway::resetResources();
+
         Config::set('statamic.editions.pro', true);
         Config::set('statamic.revisions.enabled', true);
 

--- a/tests/Routing/FrontendRoutingTest.php
+++ b/tests/Routing/FrontendRoutingTest.php
@@ -46,6 +46,8 @@ class FrontendRoutingTest extends TestCase
     #[Test]
     public function returns_resource_response_for_resource_with_custom_template()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.'.Post::class.'.template', 'custom');
 
         Runway::discoverResources();
@@ -64,6 +66,8 @@ class FrontendRoutingTest extends TestCase
     #[Test]
     public function returns_resource_response_for_resource_with_custom_layout()
     {
+        Runway::resetResources();
+
         Config::set('runway.resources.'.Post::class.'.layout', 'blog-layout');
 
         Runway::discoverResources();

--- a/tests/Routing/RoutingModelTest.php
+++ b/tests/Routing/RoutingModelTest.php
@@ -87,6 +87,7 @@ class RoutingModelTest extends TestCase
     #[Test]
     public function can_get_template()
     {
+        Runway::resetResources();
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.template', 'posts.show');
         Runway::discoverResources();
 
@@ -101,6 +102,7 @@ class RoutingModelTest extends TestCase
     #[Test]
     public function can_get_layout()
     {
+        Runway::resetResources();
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.layout', 'layouts.post');
         Runway::discoverResources();
 

--- a/tests/RunwayTest.php
+++ b/tests/RunwayTest.php
@@ -14,8 +14,6 @@ class RunwayTest extends TestCase
     #[Test]
     public function can_discover_and_get_all_resources()
     {
-        Runway::discoverResources();
-
         $all = Runway::allResources()->values();
 
         $this->assertTrue($all instanceof Collection);
@@ -40,8 +38,6 @@ class RunwayTest extends TestCase
     #[Test]
     public function can_find_resource()
     {
-        Runway::discoverResources();
-
         $find = Runway::findResource('author');
 
         $this->assertTrue($find instanceof Resource);

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -390,6 +390,8 @@ class RunwayTagTest extends TestCase
         $postBlueprint = Blueprint::find('runway::post');
         Blueprint::shouldReceive('find')->with('runway::BlogPosts')->andReturn($postBlueprint);
 
+        Runway::resetResources();
+
         Config::set('runway.resources.'.Post::class.'.handle', 'BlogPosts');
 
         Runway::discoverResources();
@@ -414,8 +416,8 @@ class RunwayTagTest extends TestCase
         $postBlueprint = Blueprint::find('runway::post');
         Blueprint::shouldReceive('find')->with('runway::BlogPosts')->andReturn($postBlueprint);
 
+        Runway::resetResources();
         Config::set('runway.resources.'.Post::class.'.handle', 'BlogPosts');
-
         Runway::discoverResources();
 
         $post = Post::factory()->create();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,7 +29,8 @@ abstract class TestCase extends AddonTestCase
         $this->runLaravelMigrations();
     }
 
-    protected function resetResources() {
+    protected function resetResources()
+    {
         Runway::resetResources();
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Blueprint;
 use Statamic\Stache\Stores\UsersStore;
 use Statamic\Statamic;
 use Statamic\Testing\AddonTestCase;
+use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\ServiceProvider;
 
 abstract class TestCase extends AddonTestCase
@@ -20,10 +21,16 @@ abstract class TestCase extends AddonTestCase
 
     protected function setUp(): void
     {
+        $this->resetResources();
+
         parent::setUp();
 
         $this->loadMigrationsFrom(__DIR__.'/__fixtures__/database/migrations');
         $this->runLaravelMigrations();
+    }
+
+    protected function resetResources() {
+        Runway::resetResources();
     }
 
     protected function resolveApplicationConfiguration($app)


### PR DESCRIPTION
This PR enables Statamic addons to register their own resources to Statamic. This enables resources to be more dynamic and don't require resources to be manually added to the config each time an addon is registrered.

The `registerResource` function should be called in the register function the addon serviceprovider.