### PR TITLE
[8.x] Update RoutingModel model property to be publicly accessible

### DIFF
--- a/src/Routing/RoutingModel.php
+++ b/src/Routing/RoutingModel.php
@@ -2,12 +2,13 @@
 
 namespace StatamicRadPack\Runway\Routing;
 
-use Illuminate\Contracts\Support\Responsable;
+use StatamicRadPack\Runway\Runway;
+use Statamic\Data\HasAugmentedData;
+use StatamicRadPack\Runway\Resource;
 use Illuminate\Database\Eloquent\Model;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Data\ContainsSupplementalData;
-use Statamic\Data\HasAugmentedData;
-use StatamicRadPack\Runway\Runway;
+use Illuminate\Contracts\Support\Responsable;
 
 class RoutingModel implements Augmentable, Responsable
 {
@@ -51,14 +52,19 @@ class RoutingModel implements Augmentable, Responsable
             ->toResponse($request);
     }
 
+    public function resource(): ?Resource
+    {
+        return Runway::findResourceByModel($this->model);
+    }
+
     public function template(): string
     {
-        return Runway::findResourceByModel($this->model)->template();
+        return $this->resource()->template();
     }
 
     public function layout(): string
     {
-        return Runway::findResourceByModel($this->model)->layout();
+        return $this->resource()->layout();
     }
 
     public function id()

--- a/src/Routing/RoutingModel.php
+++ b/src/Routing/RoutingModel.php
@@ -13,7 +13,7 @@ class RoutingModel implements Augmentable, Responsable
 {
     use ContainsSupplementalData, HasAugmentedData;
 
-    public function __construct(protected Model $model)
+    public function __construct(public Model $model)
     {
         $this->supplements = collect();
     }

--- a/src/Routing/RoutingModel.php
+++ b/src/Routing/RoutingModel.php
@@ -13,7 +13,7 @@ class RoutingModel implements Augmentable, Responsable
 {
     use ContainsSupplementalData, HasAugmentedData;
 
-    public function __construct(public Model $model)
+    public function __construct(protected Model $model)
     {
         $this->supplements = collect();
     }

--- a/src/Routing/RoutingModel.php
+++ b/src/Routing/RoutingModel.php
@@ -2,13 +2,13 @@
 
 namespace StatamicRadPack\Runway\Routing;
 
-use StatamicRadPack\Runway\Runway;
-use Statamic\Data\HasAugmentedData;
-use StatamicRadPack\Runway\Resource;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Data\ContainsSupplementalData;
-use Illuminate\Contracts\Support\Responsable;
+use Statamic\Data\HasAugmentedData;
+use StatamicRadPack\Runway\Resource;
+use StatamicRadPack\Runway\Runway;
 
 class RoutingModel implements Augmentable, Responsable
 {

--- a/tests/Routing/RoutingModelTest.php
+++ b/tests/Routing/RoutingModelTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Test;
+use StatamicRadPack\Runway\Resource;
 use StatamicRadPack\Runway\Routing\RoutingModel;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
@@ -93,7 +94,7 @@ class RoutingModelTest extends TestCase
 
         $routingModel = new RoutingModel($post);
 
-        $this->assertInstanceOf(\StatamicRadPack\Runway\Resource::class, $routingModel->resource());
+        $this->assertInstanceOf(Resource::class, $routingModel->resource());
     }
 
     #[Test]

--- a/tests/Routing/RoutingModelTest.php
+++ b/tests/Routing/RoutingModelTest.php
@@ -85,6 +85,18 @@ class RoutingModelTest extends TestCase
     }
 
     #[Test]
+    public function can_get_resource()
+    {
+        Runway::discoverResources();
+
+        $post = Post::factory()->createQuietly();
+
+        $routingModel = new RoutingModel($post);
+
+        $this->assertInstanceOf(\StatamicRadPack\Runway\Resource::class, $routingModel->resource());
+    }
+
+    #[Test]
     public function can_get_template()
     {
         Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.template', 'posts.show');


### PR DESCRIPTION
This PR adds a `resource` method on the `RoutingModel` class, allowing for easy access to the Runway Resource from the `page` variable on a runway route. I've opted to leave the `model` property as protected (as there's probably a reason for that choice).

I've also refactored the `template` and `layout` methods to utilise the new `resource` method, for consistency. Tests for these methods are passing.

Also adds a test for the new `resource` method.

For more context, please see Discord thread: https://discord.com/channels/489818810157891584/1151898550305837086/1403406370275065918

^ If the Discord link above is inaccessible, I'm building a admin toolbar (like WordPress) that's visible on the frontend, and allows the user to edit the entry they're currently on, amongst other things. I'd got this working with Statamic Collections, but the need has arisen to support Runway resources.
