### PR TITLE
[8.x] Add column existence validation for Runway resource fields

### DIFF
--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Runway\Traits;
 
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Contracts\Revisions\Revision;
@@ -63,6 +64,7 @@ trait HasRunwayResource
                     || $field->fieldtype() instanceof Hidden
                     || $field->fieldtype() instanceof Section
                     || $field->visibility() === 'computed'
+                    || !Schema::hasColumn($this->getTable(), $field->handle())
                     || Str::startsWith($field->handle(), $this->runwayResource()->nestedFieldPrefixes());
             })
             ->each(fn (Field $field) => $query->orWhere($this->getColumnForField($field->handle()), 'LIKE', '%'.$searchQuery.'%'));

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -9,7 +9,6 @@ use Statamic\Contracts\Data\Augmented;
 use Statamic\Contracts\Revisions\Revision;
 use Statamic\Fields\Field;
 use Statamic\Fields\Value;
-use Statamic\Fieldtypes\Hidden;
 use Statamic\Fieldtypes\Section;
 use Statamic\GraphQL\ResolvesValues;
 use Statamic\Revisions\Revisable;

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -59,14 +59,8 @@ trait HasRunwayResource
     public function scopeRunwaySearch(Builder $query, string $searchQuery)
     {
         $this->runwayResource()->blueprint()->fields()->all()
-            ->reject(function (Field $field) {
-                return $field->fieldtype() instanceof HasManyFieldtype
-                    || $field->fieldtype() instanceof Hidden
-                    || $field->fieldtype() instanceof Section
-                    || $field->visibility() === 'computed'
-                    || ! Schema::hasColumn($this->getTable(), $field->handle())
-                    || Str::startsWith($field->handle(), $this->runwayResource()->nestedFieldPrefixes());
-            })
+            ->filter(fn (Field $field) => Schema::hasColumn($this->getTable(), $field->handle()))
+            ->reject(fn (Field $field) => $field->visibility() === 'computed')
             ->each(fn (Field $field) => $query->orWhere($this->getColumnForField($field->handle()), 'LIKE', '%'.$searchQuery.'%'));
     }
 

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -64,7 +64,7 @@ trait HasRunwayResource
                     || $field->fieldtype() instanceof Hidden
                     || $field->fieldtype() instanceof Section
                     || $field->visibility() === 'computed'
-                    || !Schema::hasColumn($this->getTable(), $field->handle())
+                    || ! Schema::hasColumn($this->getTable(), $field->handle())
                     || Str::startsWith($field->handle(), $this->runwayResource()->nestedFieldPrefixes());
             })
             ->each(fn (Field $field) => $query->orWhere($this->getColumnForField($field->handle()), 'LIKE', '%'.$searchQuery.'%'));


### PR DESCRIPTION
We've implemented functionality in our https://github.com/rapidez/statamic package that adds a hidden collection to a Runway resource, including the collection's fields in the resource's blueprint.

However, we encountered an issue when adding new fields to the blueprint with names that don't correspond to existing columns in the resource's database table. This correctly throws an error since the column doesn't exist.

This PR adds validation to ensure that all fields being searched against the resource table have corresponding columns in the database.