### PR TITLE
Fix runway:import-collection to run on Ubuntu, and not just Mac

### DIFF
--- a/src/Console/Commands/ImportCollection.php
+++ b/src/Console/Commands/ImportCollection.php
@@ -176,7 +176,7 @@ PHP);
 
         File::put(app_path("Models/{$this->modelName}.php"), $modelContents);
 
-        spl_autoload('App\Models\\'.$this->modelName);
+        require_once app_path("Models/{$this->modelName}.php");
 
         return $this;
     }


### PR DESCRIPTION
`spl_autoload` function maps classes to lowercase filenames:
https://www.php.net/manual/en/function.spl-autoload.php
https://stackoverflow.com/a/14361521/4171578

When you run `runway:import-collection` on Mac, it works fine, since Mac filesystem is case-insensitive. On Ubuntu, running this throws an exception like:

```
class_parents(): Class App\Models\Post does not exist and could not be loaded
```

I'm running Laravel Sail in WSL2 on Windows. Changing `spl_autoload` to `require_once` fixes the issue.

