### PR TITLE
[9.x] Drop `withoutGlobalScopes` from rebuild URI cache query

### DIFF
--- a/src/Console/Commands/RebuildUriCache.php
+++ b/src/Console/Commands/RebuildUriCache.php
@@ -69,7 +69,7 @@ class RebuildUriCache extends Command
                     return;
                 }
 
-                $query = $resource->newEloquentQuery()->withoutGlobalScopes();
+                $query = $resource->newEloquentQuery();
                 $query->when($query->hasNamedScope('runwayRoutes'), fn ($query) => $query->runwayRoutes());
 
                 if (! $query->exists()) {


### PR DESCRIPTION
This pull request removes `->withoutGlobalScopes()` from the query in the `runway:rebuild-uri-cache` command.

If necessary, developers can remove global scopes using the `runwayRoutes` query scope:

```php
#[Scope]
public function runwayRoutes($query)
{
    return $query->withoutGlobalScopes();
}
```