### PR TITLE
[9.x] Use route model binding on Control Panel routes

### DIFF
--- a/src/Http/Controllers/CP/ModelRevisionsController.php
+++ b/src/Http/Controllers/CP/ModelRevisionsController.php
@@ -2,22 +2,19 @@
 
 namespace StatamicRadPack\Runway\Http\Controllers\CP;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
-use StatamicRadPack\Runway\Http\Resources\CP\Model;
+use StatamicRadPack\Runway\Http\Resources\CP\Model as ModelResource;
 use StatamicRadPack\Runway\Resource;
 
 class ModelRevisionsController extends CpController
 {
     use Traits\ExtractsFromModelFields;
 
-    public function index(Request $request, Resource $resource, $model)
+    public function index(Request $request, Resource $resource, Model $model)
     {
-        $model = $resource->newEloquentQuery()
-            ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
-            ->first();
-
         $revisions = $model
             ->revisions()
             ->reverse()
@@ -41,26 +38,18 @@ class ModelRevisionsController extends CpController
             })->reverse()->values();
     }
 
-    public function store(Request $request, Resource $resource, $model)
+    public function store(Request $request, Resource $resource, Model $model)
     {
-        $model = $resource->newEloquentQuery()
-            ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
-            ->first();
-
         $model->createRevision([
             'message' => $request->message,
             'user' => User::fromUser($request->user()),
         ]);
 
-        return new Model($model);
+        return new ModelResource($model);
     }
 
-    public function show(Request $request, Resource $resource, $model, $revisionId)
+    public function show(Request $request, Resource $resource, Model $model, $revisionId)
     {
-        $model = $resource->newEloquentQuery()
-            ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
-            ->first();
-
         $revision = $model->revision($revisionId);
         $model = $model->makeFromRevision($revision);
 
@@ -91,7 +80,7 @@ class ModelRevisionsController extends CpController
         ];
     }
 
-    protected function workingCopy($model)
+    protected function workingCopy(Model $model)
     {
         if ($model->published()) {
             return $model->workingCopy();

--- a/src/Http/Controllers/CP/PublishedModelsController.php
+++ b/src/Http/Controllers/CP/PublishedModelsController.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Http\Controllers\CP;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
@@ -12,12 +13,8 @@ class PublishedModelsController extends CpController
 {
     use Traits\ExtractsFromModelFields;
 
-    public function store(Request $request, Resource $resource, $model)
+    public function store(Request $request, Resource $resource, Model $model)
     {
-        $model = $resource->newEloquentQuery()
-            ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
-            ->first();
-
         $model = $model->publish([
             'message' => $request->message,
             'user' => User::fromUser($request->user()),
@@ -35,12 +32,8 @@ class PublishedModelsController extends CpController
         ];
     }
 
-    public function destroy(Request $request, Resource $resource, $model)
+    public function destroy(Request $request, Resource $resource, Model $model)
     {
-        $model = $resource->newEloquentQuery()
-            ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
-            ->first();
-
         $model = $model->unpublish([
             'message' => $request->message,
             'user' => User::fromUser($request->user()),

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -2,9 +2,9 @@
 
 namespace StatamicRadPack\Runway\Http\Controllers\CP;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Statamic\CP\Column;
-use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Action;
 use Statamic\Facades\Scope;
 use Statamic\Facades\User;
@@ -116,14 +116,8 @@ class ResourceController extends CpController
         ];
     }
 
-    public function edit(EditRequest $request, Resource $resource, $model)
+    public function edit(EditRequest $request, Resource $resource, Model $model)
     {
-        $model = $resource->newEloquentQuery()->firstWhere($resource->model()->qualifyColumn($resource->routeKey()), $model);
-
-        if (! $model) {
-            throw new NotFoundHttpException;
-        }
-
         $model = $model->fromWorkingCopy();
 
         $blueprint = $resource->blueprint();
@@ -165,11 +159,10 @@ class ResourceController extends CpController
         return view('runway::edit', $viewData);
     }
 
-    public function update(UpdateRequest $request, Resource $resource, $model)
+    public function update(UpdateRequest $request, Resource $resource, Model $model)
     {
         $resource->blueprint()->fields()->setParent($model)->addValues($request->all())->validator()->validate();
 
-        $model = $resource->newEloquentQuery()->firstWhere($resource->model()->qualifyColumn($resource->routeKey()), $model);
         $model = $model->fromWorkingCopy();
 
         $this->prepareModelForSaving($resource, $model, $request);

--- a/src/Http/Controllers/CP/RestoreModelRevisionController.php
+++ b/src/Http/Controllers/CP/RestoreModelRevisionController.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Http\Controllers\CP;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Revisions\WorkingCopy;
@@ -9,12 +10,8 @@ use StatamicRadPack\Runway\Resource;
 
 class RestoreModelRevisionController extends CpController
 {
-    public function __invoke(Request $request, Resource $resource, $model)
+    public function __invoke(Request $request, Resource $resource, Model $model)
     {
-        $model = $resource->model()
-            ->where($resource->model()->qualifyColumn($resource->routeKey()), $model)
-            ->first();
-
         if (! $target = $model->revision($request->revision)) {
             dd('no such revision', $request->revision);
             // todo: handle invalid revision reference

--- a/src/Http/Requests/CP/EditRequest.php
+++ b/src/Http/Requests/CP/EditRequest.php
@@ -9,10 +9,8 @@ class EditRequest extends FormRequest
 {
     public function authorize()
     {
-        $resource = $this->route('resource');
+        $model = $this->route('resource');
 
-        $model = $resource->model()::find($this->model);
-
-        return User::current()->can('edit', [$resource, $model]);
+        return User::current()->can('edit', [$model->runwayResource(), $model]);
     }
 }

--- a/src/Http/Requests/CP/IndexRequest.php
+++ b/src/Http/Requests/CP/IndexRequest.php
@@ -9,8 +9,6 @@ class IndexRequest extends FormRequest
 {
     public function authorize()
     {
-        $resource = $this->route('resource');
-
-        return User::current()->can('view', $resource);
+        return User::current()->can('view', $this->route('resource'));
     }
 }

--- a/src/Http/Requests/CP/UpdateRequest.php
+++ b/src/Http/Requests/CP/UpdateRequest.php
@@ -9,14 +9,12 @@ class UpdateRequest extends FormRequest
 {
     public function authorize()
     {
-        $resource = $this->route('resource');
+        $model = $this->route('model');
 
-        if ($resource->readOnly()) {
+        if ($model->runwayResource()->readOnly()) {
             return false;
         }
 
-        $model = $resource->model()->find($this->model);
-
-        return User::current()->can('edit', [$resource, $model]);
+        return User::current()->can('edit', [$model->runwayResource(), $model]);
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Str;
 use Spatie\ErrorSolutions\Contracts\SolutionProviderRepository;
 use Statamic\API\Middleware\Cache;
 use Statamic\Console\Commands\StaticWarm;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\GraphQL;
@@ -93,6 +94,22 @@ class ServiceProvider extends AddonServiceProvider
             }
 
             return Runway::findResource($value);
+        });
+
+        Route::bind('model', function ($value) {
+            if (! Statamic::isCpRoute()) {
+                return $value;
+            }
+
+            $resource = request()->route('resource');
+            $model = $resource?->newEloquentQuery()->firstWhere($resource->model()->qualifyColumn($resource->routeKey()), $value);
+
+            throw_unless(
+                $model,
+                new NotFoundHttpException("Model [$value] for resource [{$resource->handle()}] not found.")
+            );
+
+            return $model;
         });
 
         return $this;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -93,6 +93,11 @@ class ServiceProvider extends AddonServiceProvider
                 return $value;
             }
 
+            throw_unless(
+                Runway::hasResource($value),
+                new NotFoundHttpException("Runway resource [$value] not found.")
+            );
+
             return Runway::findResource($value);
         });
 

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -35,6 +35,17 @@ class ResourceControllerTest extends TestCase
     }
 
     #[Test]
+    public function cant_get_model_index_when_resource_doesnt_exist()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('runway.index', ['resource' => 'foo']))
+            ->assertNotFound();
+    }
+
+    #[Test]
     public function can_create_resource()
     {
         $user = User::make()->makeSuper()->save();


### PR DESCRIPTION
This pull request implements route model binding on Runway's Control Panel routes, to help tidy up controllers & form requests.

This PR also fixes an issue when accessing Runway routes with an invalid resource handle. Previously an exception (or 500 server error) would have been thrown. Now, a 404 will be thrown.