### PR TITLE
Fix sorting by nested fields

### DIFF
--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -129,7 +129,6 @@ trait HasRunwayResource
     {
         foreach ($this->runwayResource()->nestedFieldPrefixes() as $nestedFieldPrefix) {
             if (Str::startsWith($field, "{$nestedFieldPrefix}_")) {
-                $nestedFieldPrefix = Str::before($field, '_');
                 $key = Str::after($field, "{$nestedFieldPrefix}_");
 
                 return "{$nestedFieldPrefix}->{$key}";


### PR DESCRIPTION
This pull request fixes an issue when sorting by a nested field, when the nested field prefix contained multiple underscores, like `frontend_extra_attributes`.

This was happening due to the `HasRunwayResource:: getColumnForField()` method incorrectly identifying the nested field prefix (the name of the JSON column).

Fixes #716