### PR TITLE
Fixes `published() on null` error if model missing

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -345,7 +345,7 @@ abstract class BaseFieldtype extends Relationship
 
                 return $model;
             })
-            ->when($resource->hasPublishStates(), fn ($collection) => $collection->filter(fn ($model) => $model->published()))
+            ->when($resource->hasPublishStates(), fn ($collection) => $collection->filter(fn ($model) => $model?->published()))
             ->filter();
     }
 


### PR DESCRIPTION
Fixes the `Call to a member function published() on null` error.

This occurs when a model has a published column and is referenced on a page using the `belongsTo` or `hasMany` fieldtypes, and the model doesn't exist (e.g. it's been deleted).