### PR TITLE
[8.x] Publish/unpublish actions should check "publish {resource}" permission

### DIFF
--- a/src/Actions/Publish.php
+++ b/src/Actions/Publish.php
@@ -27,7 +27,7 @@ class Publish extends Action
 
     public function authorize($user, $item)
     {
-        return $user->can('edit', [$item->runwayResource(), $item]);
+        return $user->can("publish {$item->runwayResource()->handle()}");
     }
 
     public function confirmationText()

--- a/src/Actions/Unpublish.php
+++ b/src/Actions/Unpublish.php
@@ -27,7 +27,7 @@ class Unpublish extends Action
 
     public function authorize($user, $item)
     {
-        return $user->can('edit', [$item->runwayResource(), $item]);
+        return $user->can("publish {$item->runwayResource()->handle()}");
     }
 
     public function confirmationText()

--- a/tests/Actions/PublishTest.php
+++ b/tests/Actions/PublishTest.php
@@ -109,7 +109,7 @@ class PublishTest extends TestCase
     #[Test]
     public function user_with_permission_is_authorized()
     {
-        Role::make('editor')->addPermission('edit post')->save();
+        Role::make('editor')->addPermission('publish post')->save();
 
         $user = User::make()->assignRole('editor')->save();
 

--- a/tests/Actions/UnpublishTest.php
+++ b/tests/Actions/UnpublishTest.php
@@ -109,7 +109,7 @@ class UnpublishTest extends TestCase
     #[Test]
     public function user_with_permission_is_authorized()
     {
-        Role::make('editor')->addPermission('edit post')->save();
+        Role::make('editor')->addPermission('publish post')->save();
 
         $user = User::make()->assignRole('editor')->save();
 


### PR DESCRIPTION
This pull request fixes an issue with Runway's publish/unpublish actions where they were checking the "edit {resource}" instead of "publish {resource}".