### PR TITLE
[8.x] Allow custom relationship types

### DIFF
--- a/src/Relationships.php
+++ b/src/Relationships.php
@@ -37,15 +37,12 @@ class Relationships
             ->filter(fn (Field $field) => $field->fieldtype() instanceof HasManyFieldtype)
             ->each(function (Field $field): void {
                 $relationshipName = $this->model->runwayResource()->eloquentRelationships()->get($field->handle());
+                $values = $this->values[$relationshipName] ?? [];
 
                 match (get_class($relationship = $this->model->{$relationshipName}())) {
-                    HasMany::class => $this->saveHasManyRelationship($field, $relationship, $this->values[$field->handle()] ?? []),
-                    BelongsToMany::class => $this->saveBelongsToManyRelationship($field, $relationship, $this->values[$field->handle()] ?? []),
-                    default => $this->runHooks('saveCustomRelationship', [
-                        'relationship' => $relationship,
-                        'field' => $field,
-                        'values' => $this->values[$field->handle()] ?? [],
-                    ])
+                    HasMany::class => $this->saveHasManyRelationship($field, $relationship, $values),
+                    BelongsToMany::class => $this->saveBelongsToManyRelationship($field, $relationship, $values),
+                    default => $this->runHooks('saveCustomRelationship', compact('field', 'relationship', 'values')),
                 };
             });
     }


### PR DESCRIPTION
This PR adds functionality to the `Relationships` class, allowing for registration of custom save-methods. The core Runway features provide 95% of what's needed for custom relationships, but an error is thrown when using a third-party class since the only match cases are native `HasMany` and `BelongsToMany` eloquent relationships. We're just adding a default/fallback, to provide devs with an option for registering their own `save` callback.

A good example use-case would be the relationship classes found in **[the Eloquent JSON Relations package](https://github.com/staudenmeir/eloquent-json-relations?tab=readme-ov-file#many-to-many-relationships)**, where a belongs-to-many equivalent can exist in a JSON column. Here's how this could be used, from within a service provider:

```php
use Staudenmeir\EloquentJsonRelations\Relations\BelongsToJson;

Relationships::registerCustomSaveMethod(
    BelongsToJson::class,
    fn ($field, $relationship, $values) => $relationship->sync($values)->save()
);
```

And then the corresponding field from the resource's blueprint:

```yaml
-
  handle: hiring_manager_roles
  field:
    mode: select
    resource: staff_role
    relationship_name: hiringManagerRoles
    type: has_many
    display: 'Hiring Manager Roles'
```

Obviously an unsolicited feature request, but would be a big improvement on super-dynamic projects that leverage JSON columns in multiple places. Please let me know if there's anything I can do to improve this (general updates, along with tests, doc updates, etc.) and I'll make it happen. Thanks for considering this!