### PR TITLE
[8.x] Render `ResourceNotFound` exception as a 404

### DIFF
--- a/src/Exceptions/ResourceNotFound.php
+++ b/src/Exceptions/ResourceNotFound.php
@@ -2,10 +2,19 @@
 
 namespace StatamicRadPack\Runway\Exceptions;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Statamic\Exceptions\NotFoundHttpException;
+
 class ResourceNotFound extends \Exception
 {
     public function __construct(protected string $resourceHandle)
     {
         parent::__construct("Runway could not find [{$resourceHandle}]. Please ensure its configured properly and you're using the correct handle.");
+    }
+
+    public function render(Request $request): Response
+    {
+        throw new NotFoundHttpException($this->message);
     }
 }


### PR DESCRIPTION
We're experiencing some 500 errors in our sentry error tracking because of the page visits at `_ignition/execute-solution`.

In production we would like to show a 404 page here and some of our projects display content on the 404 page that is configured in Runway field types. When Runway does not register the resources it throws a 500 error instead of a 404 error because it will land on the throwing of the [ResourceNotFound](https://github.com/statamic-rad-pack/runway/blob/8.x/src/Exceptions/ResourceNotFound.php) exception.

This PR makes the excluded urls configurable so the intended functionality of excluding `_ignition` paths will still be working as it is now, but if we prefer it to be included we can.

Related: #756
