### PR TITLE
[9.x] Update revision history stack

### DIFF
--- a/resources/js/components/PublishForm.vue
+++ b/resources/js/components/PublishForm.vue
@@ -185,21 +185,20 @@
             </LivePreview>
         </PublishContainer>
 
-        <stack
-            name="revision-history"
-            v-if="showRevisionHistory"
-            @closed="showRevisionHistory = false"
-            :narrow="true"
-            v-slot="{ close }"
+        <Stack
+            ref="revisionHistoryStack"
+            size="narrow"
+            :title="__('Revision History')"
+            v-model:open="showRevisionHistory"
         >
             <revision-history
                 :index-url="actions.revisions"
                 :restore-url="actions.restore"
                 :reference="initialReference"
                 :can-restore-revisions="!readOnly"
-                @closed="close"
+                @closed="$refs.revisionHistoryStack.close()"
             />
-        </stack>
+        </Stack>
 
         <publish-actions
             v-if="confirmingPublish"
@@ -244,6 +243,7 @@ import {
     PublishLocalizations as LocalizationsCard,
     LivePreview,
     publishContextKey,
+    Stack,
 } from '@statamic/cms/ui';
 import { Pipeline, Request, BeforeSaveHooks, AfterSaveHooks, PipelineStopped } from '@statamic/cms/save-pipeline';
 import PublishActions from './PublishActions.vue';
@@ -280,6 +280,7 @@ export default {
         Subheading,
         Switch,
         Select,
+        Stack,
     },
 
     inject: {


### PR DESCRIPTION
This pull request updates the Revision History stack in the `PublishForm.vue` component, mirroring changes made to Statamic's entry publish form in https://github.com/statamic/cms/pull/13350.