### PR TITLE
[8.x] Update search indexes in a queue

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -28,6 +28,8 @@ use StatamicRadPack\Runway\Routing\RunwayUri;
 use StatamicRadPack\Runway\Search\Provider as SearchProvider;
 use StatamicRadPack\Runway\Search\Searchable;
 
+use function Illuminate\Events\queueable;
+
 class ServiceProvider extends AddonServiceProvider
 {
     protected $vite = [
@@ -224,8 +226,8 @@ class ServiceProvider extends AddonServiceProvider
         Runway::allResources()
             ->map(fn ($resource) => get_class($resource->model()))
             ->each(function ($class) {
-                Event::listen('eloquent.saved: '.$class, fn ($model) => Search::updateWithinIndexes(new Searchable($model)));
-                Event::listen('eloquent.deleted: '.$class, fn ($model) => Search::deleteFromIndexes(new Searchable($model)));
+                Event::listen('eloquent.saved: '.$class, queueable(fn ($model) => Search::updateWithinIndexes(new Searchable($model))));
+                Event::listen('eloquent.deleted: '.$class, queueable(fn ($model) => Search::deleteFromIndexes(new Searchable($model))));
             });
 
         return $this;


### PR DESCRIPTION
We found that Runway search index updates become a performance bottleneck when creating/saving models - Runway basically goes through every model either adding it or removing it from search indexes. We have tens of thousands of models. This gets worse when saving via the Statamic control panel - because that appears to save model relationships as well.

This patch pushes the search index updates to the default Laravel queue. On setups that use queues, this should effectively remove the bottleneck. (I found that Statamic core implicitly does this with an event subscriber that implements `ShouldQueue`: https://github.com/statamic/cms/blob/5.x/src/Search/UpdateItemIndexes.php.)