### PR TITLE
[8.x] Fix `unique` validation rule (again)

### DIFF
--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -179,6 +179,9 @@ class ResourceController extends CpController
 
     public function update(UpdateRequest $request, Resource $resource, $model)
     {
+        $model = $resource->newEloquentQuery()->firstWhere($resource->model()->qualifyColumn($resource->routeKey()), $model);
+        $model = $model->fromWorkingCopy();
+
         $resource->blueprint()
             ->fields()
             ->setParent($model)
@@ -188,9 +191,6 @@ class ResourceController extends CpController
                 $resource->primaryKey() => $model->getAttribute($resource->primaryKey()),
             ])
             ->validate();
-
-        $model = $resource->newEloquentQuery()->firstWhere($resource->model()->qualifyColumn($resource->routeKey()), $model);
-        $model = $model->fromWorkingCopy();
 
         $this->prepareModelForSaving($resource, $model, $request);
 


### PR DESCRIPTION
This pull request fixes an issue where the model's primary key wasn't being passed as a replacement to the validator, causing the `unique` validation rule to not work.

I've actually fixed this issue before (#388), but it's obviously been refactored out by accident.

Fixes #760

