### PR TITLE
[8.x] Prevent error when visiting URL of soft-deleted model

### DIFF
--- a/src/Routing/ResourceRoutingRepository.php
+++ b/src/Routing/ResourceRoutingRepository.php
@@ -8,7 +8,7 @@ class ResourceRoutingRepository
     {
         $runwayUri = RunwayUri::where('uri', $uri)->first();
 
-        if (! $runwayUri) {
+        if (! $runwayUri || ! $runwayUri->model) {
             return null;
         }
 


### PR DESCRIPTION
This pull request fixes an error that would occur when visiting the URL of a soft-deleted model. 

The `runway:rebuild-uris` command doesn't take global query scopes into consideration, meaning it's possible for soft-deleted models to end up in there. This is different in 9.x (https://github.com/statamic-rad-pack/runway/pull/717).

Fixes #757
