### PR TITLE
[8.x] Enable URL filter parameter support for Runway listings

### DIFF
--- a/resources/js/components/resources/Listing.vue
+++ b/resources/js/components/resources/Listing.vue
@@ -165,6 +165,7 @@ export default {
             preferencesPrefix: `runway.${this.resource}`,
             requestUrl: cp_url(`runway/${this.resource}/listing-api`),
             deletingRow: false,
+            pushQuery: true,
         }
     },
 


### PR DESCRIPTION
Enable the pushQuery option in Runway's Listing component to sync filter state with URL parameters. This brings Runway listings in line with native Statamic listings (entries, terms, users) which already support the base64-encoded ?filters= URL parameter.

This allows:
- Setting filters via URL parameters when loading a page
- Automatic URL updates when filters change
- Shareable/bookmarkable filtered views