### PR TITLE
[9.x] Supports Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       matrix:
         php: [8.3, 8.4, 8.5]
-        laravel: [12.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
           - os: windows-latest
             php: 8.5
-            laravel: 12.*
+            laravel: 13.*
             stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "spatie/ignition": "^1.15",
         "spatie/invade": "^2.1",
         "statamic/cms": "^6.5",
-        "stillat/proteus": "^4.0"
+        "stillat/proteus": "^4.2.1"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require": {
         "php": "^8.3",
         "ajthinking/archetype": "^1.0.3 || ^2.0",
-        "laravel/framework": "^12.0",
+        "laravel/framework": "^12.0 || ^13.0",
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/ignition": "^1.15",
         "spatie/invade": "^2.1",
@@ -52,9 +52,9 @@
     "require-dev": {
         "laravel/pint": "^1.0",
         "spatie/test-time": "^1.2",
-        "orchestra/testbench": "^10.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "phpunit/phpunit": "^11.0",
-        "spatie/laravel-ray": "^1.40",
+        "spatie/laravel-ray": "^1.43.6",
         "inertiajs/inertia-laravel": "^2.0.10"
     },
     "config": {
@@ -65,5 +65,7 @@
             "pixelfear/composer-dist-plugin": true,
             "composer/package-versions-deprecated": true
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/ignition": "^1.15",
         "spatie/invade": "^2.1",
-        "statamic/cms": "^6.3",
+        "statamic/cms": "^6.5",
         "stillat/proteus": "^4.0"
     },
     "require-dev": {

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Runway\Tags;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
@@ -177,7 +178,7 @@ class RunwayTag extends Tags
             'current_page' => $paginator->currentPage(),
             'prev_page' => $paginator->previousPageUrl(),
             'next_page' => $paginator->nextPageUrl(),
-            'auto_links' => $paginator->render('pagination::default'),
+            'auto_links' => (string) $paginator->render(),
             'links' => $paginator->renderArray(),
         ];
     }

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -3,7 +3,6 @@
 namespace StatamicRadPack\Runway\Tags;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;


### PR DESCRIPTION
This pull request adds Laravel 13 support to Runway. Laravel 13 is due to be released [Early March](https://x.com/taylorotwell/status/2021555106269831216).

Depends on:
* [x] https://github.com/statamic/cms/pull/13870
* [x] https://github.com/Stillat/proteus/pull/37
