### PR TITLE
[9.x] Provide `isWorkingCopy` and `revisionsEnabled` to publish container context

### DIFF
--- a/resources/js/components/PublishForm.vue
+++ b/resources/js/components/PublishForm.vue
@@ -84,6 +84,7 @@
             :errors="errors"
             :track-dirty-state="trackDirtyState"
             :remember-tab="!isInline"
+            :provide="{ isWorkingCopy, revisionsEnabled }"
         >
             <LivePreview
                 :enabled="isPreviewing"


### PR DESCRIPTION
Following on from statamic/cms#14041, this pull request ensures the `isWorkingCopy` and `revisionsEnabled` state is provided to the publish container context.