### PR TITLE
[9.x] Performance: prevent routingModel reinit

### DIFF
--- a/src/Routing/Traits/RunwayRoutes.php
+++ b/src/Routing/Traits/RunwayRoutes.php
@@ -24,7 +24,9 @@ trait RunwayRoutes
 
     public function routingModel(): RoutingModel
     {
-        $this->routingModel = new RoutingModel($this);
+        if (! $this->routingModel) {
+            $this->routingModel = new RoutingModel($this);
+        }
 
         return $this->routingModel;
     }


### PR DESCRIPTION
This small change prevents needless class reinstantiation