### PR TITLE
[8.x] Fix publish toggle in relationship stack

### DIFF
--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -141,7 +141,7 @@ class ResourceController extends CpController
                     'resource' => $resource->handle(),
                 ]),
             ]]),
-            'resource' => $resource,
+            'resource' => $request->wantsJson() ? $resource->toArray() : $resource,
             'actions' => [
                 'save' => $model->runwayUpdateUrl(),
                 'publish' => $model->runwayPublishUrl(),


### PR DESCRIPTION
## Problem

When opening a resource through a relation (opened in a stack) the `published` configuration does not seem to be correctly processed, resulting in the absence of the "Published" toggle in the sidebar.

If the same entry is opened on it's own the "Published" toggle is correctly shown.

## Cause

When the resource is requested as a relation, the resource is not converted to an array, causing some of it's data to not be correctly accessible.

## Solution

Verify if the edit request wants a JSON respone, and if so, convert the resource to an array using the `toArray()` method.