### PR TITLE
[9.x] Fix error when duplicating model with "computed" title

### DIFF
--- a/src/Actions/DuplicateModel.php
+++ b/src/Actions/DuplicateModel.php
@@ -2,7 +2,6 @@
 
 namespace StatamicRadPack\Runway\Actions;
 
-use Doctrine\DBAL\Schema\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Statamic\Actions\Action;
 use StatamicRadPack\Runway\Exceptions\ResourceNotFound;

--- a/src/Actions/DuplicateModel.php
+++ b/src/Actions/DuplicateModel.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Actions;
 
+use Doctrine\DBAL\Schema\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Statamic\Actions\Action;
 use StatamicRadPack\Runway\Exceptions\ResourceNotFound;
@@ -68,7 +69,7 @@ class DuplicateModel extends Action
     {
         $model = $original->replicate($resource->blueprint()->fields()->all()->reject->shouldBeDuplicated()->keys()->all());
 
-        if ($resource->titleField()) {
+        if ($resource->titleField() && in_array($resource->titleField(), $resource->databaseColumns())) {
             $model->setAttribute($resource->titleField(), $original->getAttribute($resource->titleField()).' (Duplicate)');
         }
 

--- a/tests/Actions/DuplicateModelTest.php
+++ b/tests/Actions/DuplicateModelTest.php
@@ -181,4 +181,23 @@ class DuplicateModelTest extends TestCase
         $this->assertNull($duplicate->start_date);
         $this->assertFalse($duplicate->published());
     }
+
+    #[Test]
+    public function it_does_not_duplicate_the_title_field_when_it_is_computed()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.title_field', 'appended_value');
+
+        $blueprint = Blueprint::find('runway::post');
+        $blueprint->ensureFieldPrepended('appended_value', ['type' => 'text']);
+
+        $post = Post::factory()->create(['slug' => 'foo']);
+
+        $this->assertCount(1, Post::all());
+
+        (new DuplicateModel)->run(collect([$post]), []);
+
+        $this->assertCount(2, Post::all());
+
+        // The fact it doesn't error is a good sign it hasn't tried to duplicate the title field.
+    }
 }


### PR DESCRIPTION
This pull request fixes an error when duplicating models with "computed" titles.

Fixes #786