### PR TITLE
[9.x] Add live preview token support to GraphQL and REST API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/ignition": "^1.15",
         "spatie/invade": "^2.1",
-        "statamic/cms": "^6.5",
+        "statamic/cms": "^6.7.2",
         "stillat/proteus": "^4.2.1"
     },
     "require-dev": {

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -18,6 +18,8 @@ class ResourceIndexQuery extends Query
 
     public function __construct(protected Resource $resource)
     {
+        parent::__construct();
+
         $this->attributes['name'] = Str::lower($this->resource->plural());
     }
 

--- a/src/GraphQL/ResourceShowQuery.php
+++ b/src/GraphQL/ResourceShowQuery.php
@@ -12,6 +12,8 @@ class ResourceShowQuery extends Query
 {
     public function __construct(protected Resource $resource)
     {
+        parent::__construct();
+
         $this->attributes['name'] = Str::lower($this->resource->singular());
     }
 
@@ -29,6 +31,20 @@ class ResourceShowQuery extends Query
 
     public function resolve($root, $args)
     {
-        return $this->resource->model()->whereStatus('published')->find($args[$this->resource->primaryKey()]);
+        $model = $this->resource->model()->find($args[$this->resource->primaryKey()]);
+
+        if (! $model) {
+            return null;
+        }
+
+        if (
+            $model->runwayResource()->hasPublishStates()
+            && $model->publishedStatus() !== 'published'
+            && ! request()->isLivePreviewOf($model)
+        ) {
+            return null;
+        }
+
+        return $model;
     }
 }

--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -20,6 +20,8 @@ class ResourceType extends Type
 
     public function fields(): array
     {
+        $this->resource->blueprint()->addGqlTypes();
+
         return $this->resource->blueprint()->fields()->toGql()
             ->merge($this->nonBlueprintFields())
             ->merge($this->nestedFields())
@@ -64,7 +66,7 @@ class ResourceType extends Type
             ->mapWithKeys(function (array $column): array {
                 $type = null;
 
-                if ($column['type_name'] === 'bigint') {
+                if (in_array($column['type_name'], ['integer', 'bigint'])) {
                     $type = GraphQL::int();
                 }
 

--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -46,11 +46,24 @@ class ApiController extends StatamicApiController
         $resource = $this->resource($resourceHandle);
         $this->resourceHandle = $resource->handle();
 
-        if (! $model = $resource->model()->whereStatus('published')->find($model)) {
+        if (! $model = $resource->model()->find($model)) {
             throw new NotFoundHttpException;
         }
 
+        $this->abortIfUnpublished($model);
+
         return ApiResource::make($model)->withBlueprintFields($this->getFieldsFromBlueprint($resource));
+    }
+
+    protected function abortIfUnpublished($model)
+    {
+        if (request()->isLivePreviewOf($model)) {
+            return;
+        }
+
+        if ($model->runwayResource()->hasPublishStates() && $model->publishedStatus() !== 'published') {
+            throw new NotFoundHttpException;
+        }
     }
 
     protected function allowedFilters()

--- a/src/ModelRepository.php
+++ b/src/ModelRepository.php
@@ -26,6 +26,7 @@ class ModelRepository
         if (
             $model->runwayResource()->hasPublishStates()
             && $model->publishedStatus() !== 'published'
+            && ! request()->isLivePreviewOf($model)
         ) {
             return null;
         }

--- a/tests/GraphQL/ResourceInterfaceTest.php
+++ b/tests/GraphQL/ResourceInterfaceTest.php
@@ -11,12 +11,12 @@ class ResourceInterfaceTest extends TestCase
     #[Test]
     public function it_adds_types()
     {
-        $this->assertEquals([
-            'runway_graphql_types_author',
-            'runway_graphql_types_post',
-            'Runway_NestedFields_Post_Values',
-            'Runway_NestedFields_Post_ExternalLinks',
-            'runway_graphql_types_user',
-        ], array_keys(GraphQL::getTypes()));
+        $types = array_keys(GraphQL::getTypes());
+
+        $this->assertContains('runway_graphql_types_author', $types);
+        $this->assertContains('runway_graphql_types_post', $types);
+        $this->assertContains('runway_graphql_types_user', $types);
+        $this->assertContains('Runway_NestedFields_Post_Values', $types);
+        $this->assertContains('Runway_NestedFields_Post_ExternalLinks', $types);
     }
 }

--- a/tests/GraphQL/ResourceShowQueryTest.php
+++ b/tests/GraphQL/ResourceShowQueryTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace StatamicRadPack\Runway\Tests\GraphQL;
+
+use Facades\Statamic\CP\LivePreview;
+use PHPUnit\Framework\Attributes\Test;
+use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
+use StatamicRadPack\Runway\Tests\TestCase;
+
+class ResourceShowQueryTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('statamic.graphql.enabled', true);
+        $app['config']->set('runway.resources.'.Post::class.'.graphql', true);
+    }
+
+    #[Test]
+    public function it_returns_published_model()
+    {
+        $post = Post::factory()->create(['title' => 'Test Post']);
+
+        $query = <<<GQL
+{
+    post(id: "{$post->id}") {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->post('/graphql', ['query' => $query])
+            ->assertOk()
+            ->assertExactJson(['data' => ['post' => [
+                'id' => $post->id,
+                'title' => 'Test Post',
+            ]]]);
+    }
+
+    #[Test]
+    public function it_returns_null_for_unpublished_model()
+    {
+        $post = Post::factory()->unpublished()->create();
+
+        $query = <<<GQL
+{
+    post(id: "{$post->id}") {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->post('/graphql', ['query' => $query])
+            ->assertOk()
+            ->assertExactJson(['data' => ['post' => null]]);
+    }
+
+    #[Test]
+    public function it_returns_unpublished_model_with_live_preview_token()
+    {
+        $post = Post::factory()->unpublished()->create(['title' => 'Unpublished Post']);
+
+        LivePreview::tokenize('test-token', $post);
+
+        $query = <<<GQL
+{
+    post(id: "{$post->id}") {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->post('/graphql', ['query' => $query])
+            ->assertOk()
+            ->assertExactJson(['data' => ['post' => null]]);
+
+        $this
+            ->post('/graphql?token=test-token', ['query' => $query])
+            ->assertOk()
+            ->assertExactJson(['data' => ['post' => [
+                'id' => $post->id,
+                'title' => 'Unpublished Post',
+            ]]]);
+    }
+
+    #[Test]
+    public function it_does_not_show_unpublished_model_with_token_for_different_model()
+    {
+        $post = Post::factory()->unpublished()->create();
+        $otherPost = Post::factory()->create();
+
+        LivePreview::tokenize('test-token', $otherPost);
+
+        $query = <<<GQL
+{
+    post(id: "{$post->id}") {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->post('/graphql?token=test-token', ['query' => $query])
+            ->assertOk()
+            ->assertExactJson(['data' => ['post' => null]]);
+    }
+}

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Tests\Http\Controllers;
 
+use Facades\Statamic\CP\LivePreview;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Config;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
@@ -181,6 +182,32 @@ class ApiControllerTest extends TestCase
 
         $this
             ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'model' => $post->id]))
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function live_preview_token_bypasses_publish_status_check()
+    {
+        $post = Post::factory()->unpublished()->create();
+
+        LivePreview::tokenize('test-token', $post);
+
+        $this
+            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'model' => $post->id, 'token' => 'test-token']))
+            ->assertOk()
+            ->assertJsonPath('data.id', $post->id);
+    }
+
+    #[Test]
+    public function live_preview_token_for_different_model_doesnt_bypass_publish_status_check()
+    {
+        $post = Post::factory()->unpublished()->create();
+        $otherPost = Post::factory()->create();
+
+        LivePreview::tokenize('test-token', $otherPost);
+
+        $this
+            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'model' => $post->id, 'token' => 'test-token']))
             ->assertNotFound();
     }
 }

--- a/tests/ModelRepositoryTest.php
+++ b/tests/ModelRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Tests;
 
+use Facades\Statamic\CP\LivePreview;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Data;
 use StatamicRadPack\Runway\Routing\RoutingModel;
@@ -62,6 +63,47 @@ class ModelRepositoryTest extends TestCase
         $runwayUri = $post->fresh()->runwayUri;
 
         $this->assertEquals($runwayUri->uri, "/posts/{$post->slug}");
+
+        $findByUri = Data::findByUri("/posts/{$post->slug}");
+
+        $this->assertNull($findByUri);
+    }
+
+    #[Test]
+    public function can_find_by_uri_when_model_is_unpublished_with_live_preview_token()
+    {
+        $post = Post::factory()->unpublished()->create();
+        $runwayUri = $post->fresh()->runwayUri;
+
+        $this->assertEquals($runwayUri->uri, "/posts/{$post->slug}");
+
+        LivePreview::tokenize('test-token', $post);
+
+        $findByUri = $this
+            ->withServerVariables(['QUERY_STRING' => 'token=test-token'])
+            ->call('GET', "/posts/{$post->slug}", ['token' => 'test-token'])
+            ->baseResponse;
+
+        $this->get("/posts/{$post->slug}?token=test-token");
+
+        $findByUri = Data::findByUri("/posts/{$post->slug}");
+
+        $this->assertNotNull($findByUri);
+        $this->assertEquals($post->fresh()->id, $findByUri->id);
+    }
+
+    #[Test]
+    public function cant_find_by_uri_when_model_is_unpublished_with_live_preview_token_for_different_model()
+    {
+        $post = Post::factory()->unpublished()->create();
+        $otherPost = Post::factory()->create();
+        $runwayUri = $post->fresh()->runwayUri;
+
+        $this->assertEquals($runwayUri->uri, "/posts/{$post->slug}");
+
+        LivePreview::tokenize('test-token', $otherPost);
+
+        $this->get("/posts/{$post->slug}?token=test-token");
 
         $findByUri = Data::findByUri("/posts/{$post->slug}");
 


### PR DESCRIPTION
This pull request adds live preview token support to Runway's GraphQL and REST API endpoints.

Previously, live preview tokens were ignored in these contexts - unpublished models were simply never returned. This PR adds support for viewing unpublished models when a valid, properly-scoped live preview token is provided.

The implementation uses Statamic's `request()->isLivePreviewOf($model)` method to ensure tokens are properly scoped to the specific model they were created for (matching the approach in statamic/cms#14304).

This PR also fixes an issue where nested GraphQL field types (like Grid items) weren't being registered. This was happening because `blueprint()->addGqlTypes()` was never called. I've fixed it by calling this method lazily when the ResourceType fields are resolved.

Additionally, this PR adds support for `integer` database columns in GraphQL (previously only `bigint` was supported).

---

Related: statamic/cms#14304
