### PR TITLE
[9.x] Fix publish toggle for custom published columns

### DIFF
--- a/resources/js/components/PublishForm.vue
+++ b/resources/js/components/PublishForm.vue
@@ -124,8 +124,8 @@
                                 <Heading :text="__('Published')" />
                                 <Switch
                                     :model-value="published"
-                                    :read-only="!canManagePublishState"
-                                    @update:model-value="setFieldValue('published', $event)"
+                                    :disabled="!canManagePublishState"
+                                    @update:model-value="setFieldValue(resource.published_column, $event)"
                                 />
                             </Panel>
 


### PR DESCRIPTION
## Summary

The Published switch on the edit form doesn't work when a Runway resource uses a custom published column (e.g. `'published' => 'is_published'`).

**Two issues fixed:**

1. **`:read-only` → `:disabled`** — The Switch component in Statamic v6 (backed by reka-ui) no longer accepts a `read-only` prop. The unknown prop falls through as an HTML attribute to reka-ui's `SwitchRoot`, which respects it and blocks interaction.

2. **Hardcoded `'published'` field handle** — `setFieldValue('published', $event)` writes to `values['published']`, but the `published` computed reads from `values[resource.published_column]`. When using a custom column like `is_published`, the toggle click writes to the wrong key and the switch never updates. Changed to `setFieldValue(resource.published_column, $event)`.

## Steps to reproduce

1. Configure a Runway resource with a custom published column:
   ```php
   'published' => 'is_published',
   ```
2. Open the resource edit form in the CP
3. Try to toggle the Published switch — it doesn't respond

## Notes

- Both fixes are needed: removing `read-only` allows the click event to fire, and using `published_column` ensures it writes to the correct reactive key