### PR TITLE
[8.x] Add sort direction option for HasManyFieldtype

### DIFF
--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -37,6 +37,20 @@ class HasManyFieldtype extends BaseFieldtype
                     'reorderable' => true,
                 ],
             ],
+            'order_direction' => [
+                'display' => __('Order Column'),
+                'instructions' => __('Which column should be used to keep track of the order?'),
+                'type' => 'radio',
+                'width' => 50,
+                'default' => 'asc',
+                'options' => [
+                    'asc' => __('Ascending (ASC)'),
+                    'desc' => __('Descending (DESC)'),
+                ],
+                'if' => [
+                    'reorderable' => true,
+                ],
+            ],
         ];
 
         return array_merge(parent::configFieldItems(), $config);

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -38,9 +38,9 @@ class HasManyFieldtype extends BaseFieldtype
                 ],
             ],
             'order_direction' => [
-                'display' => __('Order Column'),
-                'instructions' => __('Which column should be used to keep track of the order?'),
                 'type' => 'radio',
+                'display' => __('Order Direction'),
+                'instructions' => __('Which direction should the items be sorted in?'),
                 'width' => 50,
                 'default' => 'asc',
                 'options' => [

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -38,14 +38,14 @@ class HasManyFieldtype extends BaseFieldtype
                 ],
             ],
             'order_direction' => [
-                'type' => 'radio',
                 'display' => __('Order Direction'),
                 'instructions' => __('Which direction should the items be sorted in?'),
+                'type' => 'select',
                 'width' => 50,
                 'default' => 'asc',
                 'options' => [
-                    'asc' => __('Ascending (ASC)'),
-                    'desc' => __('Descending (DESC)'),
+                    'asc' => __('Ascending'),
+                    'desc' => __('Descending'),
                 ],
                 'if' => [
                     'reorderable' => true,

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -82,10 +82,11 @@ trait PreparesModels
                     // When re-ordering is enabled, ensure the models are returned in the correct order.
                     if ($field->get('reorderable', false)) {
                         $orderColumn = $field->get('order_column');
+                        $orderDirection = $field->get('order_direction') ?? 'ASC';
                         $relationshipName = $resource->eloquentRelationships()->get($field->handle());
 
                         $value = $model->{$relationshipName}()
-                            ->reorder($orderColumn, 'ASC')
+                            ->reorder($orderColumn, strtoupper($orderDirection))
                             ->get();
                     }
                 }

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -82,11 +82,11 @@ trait PreparesModels
                     // When re-ordering is enabled, ensure the models are returned in the correct order.
                     if ($field->get('reorderable', false)) {
                         $orderColumn = $field->get('order_column');
-                        $orderDirection = $field->get('order_direction') ?? 'ASC';
+                        $orderDirection = $field->get('order_direction', 'asc');
                         $relationshipName = $resource->eloquentRelationships()->get($field->handle());
 
                         $value = $model->{$relationshipName}()
-                            ->reorder($orderColumn, strtoupper($orderDirection))
+                            ->reorder($orderColumn, $orderDirection)
                             ->get();
                     }
                 }


### PR DESCRIPTION
This adds a sort direction option to the HasManyFieldtype. Default value + fallback for non-existing config is set to ASC (which was the default before).