### PR TITLE
[9.x] Searchable authorization

### DIFF
--- a/src/Search/Searchable.php
+++ b/src/Search/Searchable.php
@@ -93,6 +93,11 @@ class Searchable implements Augmentable, ContainsQueryableValues, Contract
         return $this->resource->name();
     }
 
+    public function getCpSearchResultIcon(): string
+    {
+        return $this->resource->icon();
+    }
+
     public function newAugmentedInstance(): Augmented
     {
         foreach ($this->supplements as $key => $value) {

--- a/src/Search/SearchablePolicy.php
+++ b/src/Search/SearchablePolicy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace StatamicRadPack\Runway\Search;
+
+class SearchablePolicy
+{
+    public function view($user, Searchable $searchable)
+    {
+        return $user->can('view', [$searchable->resource(), $searchable->model()]);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -152,6 +152,11 @@ class ServiceProvider extends AddonServiceProvider
             }
         });
 
+        Gate::policy(
+            \StatamicRadPack\Runway\Search\Searchable::class,
+            \StatamicRadPack\Runway\Search\SearchablePolicy::class
+        );
+
         return $this;
     }
 

--- a/tests/Search/SearchablePolicyTest.php
+++ b/tests/Search/SearchablePolicyTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace StatamicRadPack\Runway\Tests\Search;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Role;
+use Statamic\Facades\User;
+use StatamicRadPack\Runway\Search\Searchable;
+use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
+use StatamicRadPack\Runway\Tests\TestCase;
+
+class SearchablePolicyTest extends TestCase
+{
+    #[Test]
+    public function user_with_view_permission_can_view_searchable()
+    {
+        $post = Post::factory()->create();
+        $searchable = new Searchable($post);
+
+        Role::make('test')->addPermission('view post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertTrue($user->can('view', $searchable));
+    }
+
+    #[Test]
+    public function user_without_view_permission_cannot_view_searchable()
+    {
+        $post = Post::factory()->create();
+        $searchable = new Searchable($post);
+
+        Role::make('test')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertFalse($user->can('view', $searchable));
+    }
+
+    #[Test]
+    public function super_user_can_view_searchable()
+    {
+        $post = Post::factory()->create();
+        $searchable = new Searchable($post);
+
+        $user = User::make()->makeSuper()->save();
+
+        $this->assertTrue($user->can('view', $searchable));
+    }
+}

--- a/tests/Search/SearchableTest.php
+++ b/tests/Search/SearchableTest.php
@@ -102,6 +102,16 @@ class SearchableTest extends TestCase
     }
 
     #[Test]
+    public function can_get_cp_search_result_icon()
+    {
+        $post = Post::factory()->create();
+
+        $searchable = new Searchable($post);
+
+        $this->assertIsString($searchable->getCpSearchResultIcon());
+    }
+
+    #[Test]
     public function can_get_new_augmented_instance()
     {
         $post = Post::factory()->create();


### PR DESCRIPTION
This pull request fixes an issue where Runway models in the Statamic CP command palette search would fail authorization and then crash.

There were two separate problems:

* Runway searchables failed authorization checks
   * This was happening because Statamic CP search filters results using `User::current()->can('view', $item->getSearchable())`, but the `Searchable` class didn't have a policy registered.
   * I've fixed it by adding a `SearchablePolicy` that delegates to the existing `ResourcePolicy`.
* Runway searchables crashed due to missing `getCpSearchResultIcon()` method
   * This was happening because Statamic's CP search result rendering expects this method.
   * I've fixed it by adding the method to the `Searchable` class.

Fixes #796