### PR TITLE
[9.x] Replace spatie/ignition with spatie/error-solutions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "ajthinking/archetype": "^1.0.3 || ^2.0",
         "laravel/framework": "^12.0 || ^13.0",
         "pixelfear/composer-dist-plugin": "^0.1.5",
-        "spatie/ignition": "^1.15",
+        "spatie/error-solutions": "^1.0 || ^2.0",
         "spatie/invade": "^2.1",
         "statamic/cms": "^6.10",
         "stillat/proteus": "^4.2.1"

--- a/src/Exceptions/EmptyBlueprintException.php
+++ b/src/Exceptions/EmptyBlueprintException.php
@@ -2,9 +2,9 @@
 
 namespace StatamicRadPack\Runway\Exceptions;
 
-use Spatie\Ignition\Contracts\BaseSolution;
-use Spatie\Ignition\Contracts\ProvidesSolution;
-use Spatie\Ignition\Contracts\Solution;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
 
 class EmptyBlueprintException extends \Exception implements ProvidesSolution
 {

--- a/src/Ignition/SolutionProviders/TraitMissing.php
+++ b/src/Ignition/SolutionProviders/TraitMissing.php
@@ -2,7 +2,7 @@
 
 namespace StatamicRadPack\Runway\Ignition\SolutionProviders;
 
-use Spatie\Ignition\Contracts\HasSolutionsForThrowable;
+use Spatie\ErrorSolutions\Contracts\HasSolutionsForThrowable;
 use StatamicRadPack\Runway\Ignition\Solutions\AddTraitToModel;
 use Throwable;
 

--- a/src/Ignition/Solutions/AddTraitToModel.php
+++ b/src/Ignition/Solutions/AddTraitToModel.php
@@ -4,7 +4,7 @@ namespace StatamicRadPack\Runway\Ignition\Solutions;
 
 use Archetype\Facades\PHPFile;
 use Illuminate\Support\Str;
-use Spatie\Ignition\Contracts\RunnableSolution;
+use Spatie\ErrorSolutions\Contracts\RunnableSolution;
 use StatamicRadPack\Runway\Traits\HasRunwayResource;
 
 class AddTraitToModel implements RunnableSolution


### PR DESCRIPTION
This pull request replaces the `spatie/ignition` dependency with `spatie/error-solutions`.

This was needed because `spatie/ignition` conflicts with the newer versions of Symfony and Laravel required by Statamic 6 / Laravel 13, preventing Runway from being installed into a fresh Statamic site. `spatie/error-solutions` is the successor package and is already used by `statamic/cms` itself.

This PR also updates the three source files that were still importing contracts from the `Spatie\Ignition\Contracts` namespace to use the `Spatie\ErrorSolutions\Contracts` namespace instead.

Fixes https://github.com/statamic-rad-pack/runway/issues/802
Related: statamic/statamic#135