### PR TITLE
[9.x] Qualify the primary key in queries

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -293,7 +293,7 @@ abstract class BaseFieldtype extends Relationship
                     $item = $item->first()->{$resource->primaryKey()} ?? null;
                 }
 
-                $model = $resource->model()->firstWhere($resource->primaryKey(), $item);
+                $model = $resource->model()->firstWhere($resource->qualifiedPrimaryKey(), $item);
             } else {
                 $model = $item;
             }
@@ -356,7 +356,7 @@ abstract class BaseFieldtype extends Relationship
                                 fn ($query) => $query->with(Arr::wrap($this->config('with'))),
                                 fn ($query) => $query->with($resource->eagerLoadingRelationships())
                             )
-                            ->firstWhere($resource->primaryKey(), $model);
+                            ->firstWhere($resource->qualifiedPrimaryKey(), $model);
                     });
                 }
 
@@ -386,7 +386,7 @@ abstract class BaseFieldtype extends Relationship
     protected function toItemArray($id)
     {
         $resource = Runway::findResource($this->config('resource'));
-        $model = $id instanceof Model ? $id : $resource->model()->runway()->firstWhere($resource->primaryKey(), $id);
+        $model = $id instanceof Model ? $id : $resource->model()->runway()->firstWhere($resource->qualifiedPrimaryKey(), $id);
 
         if (! $model) {
             return $this->invalidItemArray($id);

--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -49,7 +49,7 @@ class ResourceType extends Type
             if (! $model instanceof Model) {
                 $resource = Runway::findResource(Str::replace('runway_graphql_types_', '', $info->parentType->name));
 
-                $model = $resource->model()->firstWhere($resource->primaryKey(), $model);
+                $model = $resource->model()->firstWhere($resource->qualifiedPrimaryKey(), $model);
             }
 
             return $model->resolveGqlValue($info->fieldName);

--- a/src/Relationships.php
+++ b/src/Relationships.php
@@ -51,7 +51,7 @@ class Relationships
     {
         $relatedResource = Runway::findResource($field->fieldtype()->config('resource'));
 
-        $deleted = $relationship->whereNotIn($relatedResource->primaryKey(), $values)->get()
+        $deleted = $relationship->whereNotIn($relatedResource->qualifiedPrimaryKey(), $values)->get()
             ->each(fn (Model $model) => match ($this->getUnlinkBehaviorForHasManyRelationship($relationship)) {
                 'unlink' => $model->update([$relationship->getForeignKeyName() => null]),
                 'delete' => $model->delete(),

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -289,6 +289,11 @@ class Resource
         return $this->model()->getKeyName();
     }
 
+    public function qualifiedPrimaryKey(): string
+    {
+        return $this->model()->getQualifiedKeyName();
+    }
+
     public function routeKey(): string
     {
         return $this->model()->getRouteKeyName() ?? 'id';

--- a/src/Scopes/Fields/Models.php
+++ b/src/Scopes/Fields/Models.php
@@ -58,7 +58,7 @@ class Models extends FieldtypeFilter
 
         $ids = $relatedResource->model()->query()
             ->where($field, $operator, $value)
-            ->select($relatedResource->primaryKey())
+            ->select($relatedResource->qualifiedPrimaryKey())
             ->get()
             ->pluck($relatedResource->primaryKey())
             ->toArray();
@@ -70,7 +70,7 @@ class Models extends FieldtypeFilter
             $queryingResource = Runway::findResourceByModel($query->getModel());
 
             $query->whereHas($queryingResource->eloquentRelationships()->get($this->fieldtype->field()->handle()), function (Builder $query) use ($relatedResource, $ids) {
-                $query->whereIn($relatedResource->primaryKey(), $ids);
+                $query->whereIn($relatedResource->qualifiedPrimaryKey(), $ids);
             });
         } else {
             $query->whereIn($this->fieldtype->field()->handle(), $ids);

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -100,7 +100,7 @@ class RunwayTag extends Tags
                 $relationshipResource = Runway::findResource($this->resource->blueprint()->field($key)->config()['resource']);
 
                 $query->whereHas($relationshipName, function ($query) use ($value, $relationshipResource) {
-                    $query->whereIn($relationshipResource->databaseTable().'.'.$relationshipResource->primaryKey(), Arr::wrap($value));
+                    $query->whereIn($relationshipResource->qualifiedPrimaryKey(), Arr::wrap($value));
                 });
             } else {
                 $query->where($this->resource->model()->getColumnForField($key), $value);


### PR DESCRIPTION
This fixes an edge case that occurs when you have a resource where querying it requires disambiguating (qualifying) the primary key. For example, the specific case we ran into was using product attributes from Magento. Within our code, we join the `eav_attribute` table onto the `catalog_eav_attribute` table. The primary key of the `eav_attribute` table is called `attribute_id`, which is also the column name they use for the foreign key in `catalog_eav_attribute`.

This is (unfortunately) a rather common occurrence in Magento so we often already have to qualify columns everywhere. However, we run into an issue with Runway because it currently assumes primary keys don't need to be qualified when it does queries.

---

I couldn't change the `primaryKey()` function itself as it also gets used outside of queries, so instead I made a new `qualifiedPrimaryKey()` function. I think I caught all of the usages of the function here that relate to querying.

Note: I have not written a test for this right now, as it would require modifying the testing database/migrations structure to fit this specific edge case. That seemed overkill, and frankly just a little bit out of my wheelhouse 😅