### PR TITLE
[9.x] Fix updated_at timestamp not updating when field is read-only

### DIFF
--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -182,6 +182,16 @@ trait PreparesModels
                     return;
                 }
 
+                // Skip read-only timestamp columns so Laravel's automatic
+                // timestamp handling isn't prevented by a stale value.
+                if (
+                    $field->visibility() === 'read_only'
+                    && $model->usesTimestamps()
+                    && in_array($field->handle(), [$model->getCreatedAtColumn(), $model->getUpdatedAtColumn()])
+                ) {
+                    return;
+                }
+
                 $model->setAttribute($field->handle(), $processedValue);
             });
     }

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -678,7 +678,7 @@ class ResourceControllerTest extends TestCase
     }
 
     #[Test]
-    public function can_update_resource_and_ensure__field_isnt_saved_to_database()
+    public function can_update_resource_and_ensure_field_with_save_false_isnt_saved_to_database()
     {
         $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -678,6 +678,46 @@ class ResourceControllerTest extends TestCase
     }
 
     #[Test]
+    public function can_update_resource_and_ensure_read_only_timestamp_field_doesnt_prevent_timestamp_update()
+    {
+        $postBlueprint = Blueprint::find('runway::post');
+
+        Blueprint::shouldReceive('find')->with('user')->andReturn(new \Statamic\Fields\Blueprint);
+        Blueprint::shouldReceive('find')->with('runway::author')->andReturn(new \Statamic\Fields\Blueprint);
+        Blueprint::shouldReceive('find')->with('runway::post')->andReturn($postBlueprint->ensureField('updated_at', [
+            'type' => 'date',
+            'time_enabled' => true,
+            'visibility' => 'read_only',
+        ]));
+        Blueprint::shouldReceive('getAdditionalNamespaces')->andReturn(collect(['runway' => base_path('resources/blueprints/runway')]))->zeroOrMoreTimes();
+
+        $post = Post::factory()->create();
+        $user = User::make()->makeSuper()->save();
+
+        $originalUpdatedAt = $post->updated_at;
+
+        $this->travel(5)->minutes();
+
+        $this
+            ->actingAs($user)
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
+                'published' => true,
+                'title' => 'Santa is coming home',
+                'slug' => 'santa-is-coming-home',
+                'body' => $post->body,
+                'author_id' => [$post->author_id],
+                'updated_at' => $originalUpdatedAt->toIso8601ZuluString('millisecond'),
+            ])
+            ->assertOk()
+            ->assertJsonStructure(['data', 'saved']);
+
+        $post->refresh();
+
+        $this->assertEquals('Santa is coming home', $post->title);
+        $this->assertTrue($post->updated_at->gt($originalUpdatedAt));
+    }
+
+    #[Test]
     public function can_update_resource_and_ensure_field_with_save_false_isnt_saved_to_database()
     {
         $post = Post::factory()->create();


### PR DESCRIPTION
This pull request fixes an issue where the `updated_at` timestamp wasn't being updated when it was configured as a `read_only` field in the blueprint.

This was happening because `read_only` fields are still saved, so the value was run through the fieldtype's `process()` method and set on the model via `setAttribute`. This made the `updated_at` attribute dirty in the model's attributes array, which prevented Laravel's `updateTimestamps()` from auto-updating the timestamp (it skips columns that are already dirty), causing the stale value to be saved.

This PR fixes it by skipping `setAttribute` for timestamp columns (`updated_at`/`created_at`) when the field is `read_only` and the model uses timestamps, allowing Laravel's automatic timestamp handling to work as expected.

Fixes #805