### PR TITLE
[9.x] Publish form tweaks

### DIFF
--- a/resources/js/components/PublishForm.vue
+++ b/resources/js/components/PublishForm.vue
@@ -77,7 +77,7 @@
             v-if="blueprint"
             ref="container"
             :name="publishContainer"
-            :reference="initialReference"
+            :reference="reference"
             :blueprint="blueprint"
             v-model="values"
             :meta="meta"
@@ -335,6 +335,7 @@ export default {
             values: clone(this.initialValues),
             visibleValues: {},
             meta: clone(this.initialMeta),
+            reference: this.initialReference,
             isWorkingCopy: this.initialIsWorkingCopy,
             isPreviewing: false,
             tabsVisible: true,

--- a/resources/js/components/PublishForm.vue
+++ b/resources/js/components/PublishForm.vue
@@ -82,6 +82,7 @@
             v-model="values"
             :meta="meta"
             :errors="errors"
+            :read-only="readOnly"
             :track-dirty-state="trackDirtyState"
             :remember-tab="!isInline"
             :provide="{ isWorkingCopy, revisionsEnabled }"


### PR DESCRIPTION
This pull request brings across a couple of publish form changes from statamic/cms:

* Fixes an issue where fields in read-only publish forms remained editable for users without edit permissions, despite the "Read Only" badge being displayed.
   * This was happening because the `readOnly` state was tracked in the component data but never passed down to the `PublishContainer` as a prop.
   * I've fixed it by adding `:read-only="readOnly"` to the `PublishContainer`.
* Makes `reference` a reactive data property instead of passing `initialReference` directly to the `PublishContainer`, keeping it in sync with upstream.

Related: statamic/cms#14623
Related: statamic/cms#14548