### PR TITLE
[9.x] Fix toggle field filter

### DIFF
--- a/src/Scopes/Fields.php
+++ b/src/Scopes/Fields.php
@@ -50,6 +50,14 @@ class Fields extends BaseFieldsFilter
     {
         $values = array_filter($values);
 
-        return Arr::has($values, 'operator') && Arr::has($values, 'value');
+        if (! $operator = Arr::get($values, 'operator')) {
+            return Arr::has($values, 'value');
+        }
+
+        if (in_array($operator, ['null', 'not-null'])) {
+            return true;
+        }
+
+        return Arr::has($values, 'value');
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where toggle fields couldn't be filtered on resource listings.

This was happening because the `isComplete` method required both an `operator` and a `value` to be present, but toggle fields only provide a `value` without an operator.

This PR fixes it by updating the `isComplete` check to handle toggle fields (no operator, just a value) and `null`/`not-null` operators (no value needed).

Fixes #810
Related: statamic/cms#14015