### PR TITLE
[9.x] Fix perPage limit in relationship stack listings

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -191,7 +191,7 @@ abstract class BaseFieldtype extends Relationship
 
         $this->applyOrderingToIndexQuery($query, $request);
 
-        $results = ($paginate = $request->boolean('paginate', true)) ? $query->paginate() : $query->get();
+        $results = ($paginate = $request->boolean('paginate', true)) ? $query->paginate($request->integer('perPage', 15)) : $query->get();
 
         $items = $results->map(fn ($item) => $item instanceof Result ? $item->getSearchable()->model() : $item);
 


### PR DESCRIPTION
This pull request fixes an issue where the `perPage` parameter was not being passed to `paginate()` in relationship stack listings, causing pagination to ignore the requested page size.

This was happening because `paginate()` was being called without any arguments, so it always used the default page size.

This PR fixes it by passing `$request->integer('perPage', 15)` to the `paginate()` call.

Related: statamic/cms#14629