### PR TITLE
[9.x] Fix failing date tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/error-solutions": "^1.0 || ^2.0",
         "spatie/invade": "^2.1",
-        "statamic/cms": "^6.10",
+        "statamic/cms": "^6.17",
         "stillat/proteus": "^4.2.1"
     },
     "require-dev": {

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -474,10 +474,13 @@ class ResourceControllerTest extends TestCase
             ]))
             ->assertOk();
 
-        // Time isn't enabled, so expect just the date.
-        $this->assertEquals(
-            $post->created_at->startOfDay()->format('Y-m-d'),
-            $response->inertiaProps('values')['created_at']
+        // Time isn't enabled, so expect just the date (or full ISO string on older CMS versions).
+        $this->assertContains(
+            $response->inertiaProps('values')['created_at'],
+            [
+                $post->created_at->startOfDay()->format('Y-m-d'),
+                $post->created_at->startOfDay()->toIso8601ZuluString('millisecond'),
+            ]
         );
     }
 

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -474,13 +474,10 @@ class ResourceControllerTest extends TestCase
             ]))
             ->assertOk();
 
-        // Time isn't enabled, so expect just the date (or full ISO string on older CMS versions).
-        $this->assertContains(
-            $response->inertiaProps('values')['created_at'],
-            [
-                $post->created_at->startOfDay()->format('Y-m-d'),
-                $post->created_at->startOfDay()->toIso8601ZuluString('millisecond'),
-            ]
+        // Time isn't enabled, so expect just the date.
+        $this->assertEquals(
+            $post->created_at->startOfDay()->format('Y-m-d'),
+            $response->inertiaProps('values')['created_at']
         );
     }
 

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -474,9 +474,9 @@ class ResourceControllerTest extends TestCase
             ]))
             ->assertOk();
 
-        // Time isn't enabled, so expect the time to be 00:00:00.
+        // Time isn't enabled, so expect just the date.
         $this->assertEquals(
-            $post->created_at->startOfDay()->toIso8601ZuluString('millisecond'),
+            $post->created_at->startOfDay()->format('Y-m-d'),
             $response->inertiaProps('values')['created_at']
         );
     }


### PR DESCRIPTION
This pull request fixes a test failure in `can_edit_resource_with_date_field_with_default_format` caused by an upstream change in Statamic CMS.

This was happening because CMS now returns just the date string (e.g. `2026-05-11`) when time is disabled on a date field, rather than a full ISO 8601 Zulu string (e.g. `2026-05-11T00:00:00.000Z`).

This PR fixes it by updating the test expectation to use `format('Y-m-d')` instead of `toIso8601ZuluString('millisecond')`.