### PR TITLE
[9.x] Add `.npmrc` file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+audit=true
+ignore-scripts=true
+min-release-age=3


### PR DESCRIPTION
This PR adds an `.npmrc` file to reduce the risk of installing packages with supply-chain vulnerabilities.