### PR TITLE
[9.x] Authorize relationship fieldtype data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/error-solutions": "^1.0 || ^2.0",
         "spatie/invade": "^2.1",
-        "statamic/cms": "^6.17",
+        "statamic/cms": "^6.20",
         "stillat/proteus": "^4.2.1"
     },
     "require-dev": {

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -13,6 +13,7 @@ use Statamic\CP\Column;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Scope;
 use Statamic\Facades\Search;
+use Statamic\Facades\User;
 use Statamic\Fieldtypes\Relationship;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Query\OrderBy;
@@ -187,6 +188,10 @@ abstract class BaseFieldtype extends Relationship
 
     public function getIndexItems($request)
     {
+        if (! User::current()?->can('view', $this->resource())) {
+            return collect();
+        }
+
         $query = $this->getIndexQuery($request);
 
         $this->applyOrderingToIndexQuery($query, $request);
@@ -381,6 +386,11 @@ abstract class BaseFieldtype extends Relationship
             ->setPreferred("runway.{$resource->handle()}.columns")
             ->rejectUnlisted()
             ->values();
+    }
+
+    protected function authorizeItemData($id): bool
+    {
+        return (bool) User::current()?->can('view', $this->resource());
     }
 
     protected function toItemArray($id)

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
+use Statamic\Facades\User;
 use Statamic\Fields\Field;
 use Statamic\Http\Requests\FilteredRequest;
 use StatamicRadPack\Runway\Fieldtypes\BelongsToFieldtype;
@@ -25,6 +26,8 @@ class BelongsToFieldtypeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->actingAs(User::make()->makeSuper()->save());
 
         $this->fieldtype = tap(new BelongsToFieldtype)
             ->setField(new Field('author', [

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Entry;
+use Statamic\Facades\User;
 use Statamic\Fields\Field;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
@@ -28,6 +29,8 @@ class HasManyFieldtypeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->actingAs(User::make()->makeSuper()->save());
 
         $this->fieldtype = tap(new HasManyFieldtype)
             ->setField(new Field('posts', [


### PR DESCRIPTION
This pull request adds authorization checks to Runway's relationship fieldtypes to align with Statamic CMS PRs statamic/cms#14718 and statamic/cms#14719.

Users without `view` permission for a resource will now see an empty picker when browsing, and invalid placeholders for existing selections they can't access. This matches the behaviour introduced in Statamic core for entries, terms, users, and other relationship fieldtypes.

This PR also bumps the minimum `statamic/cms` requirement to `^6.20` to ensure the `authorizeItemData` method exists in the parent `Relationship` class.

---

Related: statamic/cms#14718
Related: statamic/cms#14719