### PR TITLE
[9.x] Fix date filter `between` operator not working in runway listing

### DIFF
--- a/src/Scopes/Fields.php
+++ b/src/Scopes/Fields.php
@@ -59,7 +59,7 @@ class Fields extends BaseFieldsFilter
         }
 
         if ($operator === 'between') {
-          return Arr::has($values, 'range_value.start') && Arr::has($values, 'range_value.end');
+            return Arr::has($values, 'range_value.start') && Arr::has($values, 'range_value.end');
         }
 
         return Arr::has($values, 'value');

--- a/src/Scopes/Fields.php
+++ b/src/Scopes/Fields.php
@@ -58,6 +58,10 @@ class Fields extends BaseFieldsFilter
             return true;
         }
 
+        if ($operator === 'between') {
+          return Arr::has($values, 'range_value.start') && Arr::has($values, 'range_value.end');
+        }
+
         return Arr::has($values, 'value');
     }
 }


### PR DESCRIPTION
## Problem
When filtering a Runway resource listing by a date field using the `between` operator,
the filter is silently ignored and all results are returned unfiltered.

This is because `isComplete()` only checks for the `value` key, but the `between`
operator sends `range_value` instead:

- `after` / `before` → `{ "operator": ">", "value": "..." }`
- `between` → `{ "operator": "between", "range_value": { "start": "...", "end": "..." } }`

So `isComplete()` always returns `false` for `between`, preventing the filter from ever being applied.

## Fix
Add a `between` case to `isComplete()` that checks for `range_value.start` and `range_value.end`.