### PR TITLE
[9.x] Fix belongs_to not being populated during inline has_many creation

### DIFF
--- a/resources/js/components/PublishForm.vue
+++ b/resources/js/components/PublishForm.vue
@@ -474,7 +474,7 @@ export default {
         },
 
         parentContainer() {
-            return this.publishContext?.parentContainer;
+            return this.publishContext;
         },
     },
 


### PR DESCRIPTION
Goal is to fix https://github.com/statamic-rad-pack/runway/issues/799