### PR TITLE
[9.x] Implement `Data::find()` support for Runway models

### DIFF
--- a/src/ModelRepository.php
+++ b/src/ModelRepository.php
@@ -10,6 +10,29 @@ class ModelRepository
     protected $substitutionsById = [];
     protected $substitutionsByUri = [];
 
+    public function find(string $reference)
+    {
+        $fullReference = "runway::{$reference}";
+
+        if ($substitute = Arr::get($this->substitutionsById, $fullReference)) {
+            return $substitute;
+        }
+
+        if (! str_contains($reference, '::')) {
+            return null;
+        }
+
+        [$handle, $id] = explode('::', $reference, 2);
+
+        $resource = Runway::allResources()->get($handle);
+
+        if (! $resource) {
+            return null;
+        }
+
+        return $resource->model()->find($id);
+    }
+
     public function findByUri(string $uri)
     {
         if ($substitute = Arr::get($this->substitutionsByUri, $uri)) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -287,7 +287,7 @@ class ServiceProvider extends AddonServiceProvider
             $this->app->singleton(ModelRepository::class);
 
             $this->app->get(\Statamic\Contracts\Data\DataRepository::class)
-                ->setRepository('runway-resources', ModelRepository::class);
+                ->setRepository('runway', ModelRepository::class);
 
             StaticWarm::hook('additional', function ($urls, $next) {
                 return $next($urls->merge(RunwayUri::select('uri')->pluck('uri')->all()));

--- a/tests/ModelRepositoryTest.php
+++ b/tests/ModelRepositoryTest.php
@@ -11,6 +11,33 @@ use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 class ModelRepositoryTest extends TestCase
 {
     #[Test]
+    public function can_find_by_reference()
+    {
+        $post = Post::factory()->create();
+
+        $found = Data::find("runway::post::{$post->id}");
+
+        $this->assertNotNull($found);
+        $this->assertEquals($post->id, $found->id);
+    }
+
+    #[Test]
+    public function cant_find_by_reference_when_model_doesnt_exist()
+    {
+        $found = Data::find('runway::post::99999');
+
+        $this->assertNull($found);
+    }
+
+    #[Test]
+    public function cant_find_by_reference_when_resource_doesnt_exist()
+    {
+        $found = Data::find('runway::nonexistent::12345');
+
+        $this->assertNull($found);
+    }
+
+    #[Test]
     public function can_find_by_uri()
     {
         $post = Post::factory()->create();


### PR DESCRIPTION
This pull request implements `Data::find()` support for Runway models, allowing them to be resolved via their reference string (e.g. `runway::post::uuid`).

This was needed because Statamic 6's new [`ReplicatorSetController`](https://github.com/statamic/cms/blob/32005d0d5ed4c7cd620fe641a49fdd796d7087de/src/Http/Controllers/CP/Fieldtypes/ReplicatorSetController.php#L57) uses `Data::find()` to resolve the parent model when adding sets. Without this, users encountered a database error:

```
SQLSTATE[22P02]: invalid input syntax for type uuid: 'runway::{model}::{uuid}'
```

This PR implements it by:
1. Changing the `DataRepository` registration key from `runway-resources` to `runway` to match the reference prefix used by Runway models
2. Adding a `find()` method to `ModelRepository` that parses `handle::id` references and returns the corresponding Eloquent model

Fixes #809