### PR TITLE
[9.x] Invalidate REST API cache when Runway models are saved or deleted

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use Spatie\ErrorSolutions\Contracts\SolutionProviderRepository;
+use Statamic\API\Cacher;
 use Statamic\API\Middleware\Cache;
 use Statamic\Console\Commands\StaticWarm;
 use Statamic\Exceptions\NotFoundHttpException;
@@ -276,9 +277,21 @@ class ServiceProvider extends AddonServiceProvider
             ->each(function ($class) {
                 Event::listen('eloquent.saved: '.$class, queueable(fn ($model) => Search::updateWithinIndexes(new Searchable($model))));
                 Event::listen('eloquent.deleted: '.$class, queueable(fn ($model) => Search::deleteFromIndexes(new Searchable($model))));
+
+                Event::listen('eloquent.saved: '.$class, fn () => $this->invalidateApiCache());
+                Event::listen('eloquent.deleted: '.$class, fn () => $this->invalidateApiCache());
             });
 
         return $this;
+    }
+
+    protected function invalidateApiCache(): void
+    {
+        if (! config('statamic.api.enabled') || ! config('statamic.api.cache.expiry')) {
+            return;
+        }
+
+        app(Cacher::class)->handleInvalidationEvent(new class extends \Statamic\Events\Event {});
     }
 
     protected function bootDataRepository(): self


### PR DESCRIPTION
This pull request fixes an issue where the REST API response cache is not invalidated when a Runway model is saved or deleted.

This was happening because Statamic's API cache subscriber only listens for Statamic-specific content events (like `EntrySaved`, `AssetDeleted`, etc.), but Runway models fire Eloquent events (`eloquent.saved`, `eloquent.deleted`) which weren't connected to the API cache invalidation system.

This PR fixes it by extending the existing `bootModelEventListeners()` method (already used for search indexing) to also invalidate the API cache when Eloquent save/delete events occur.

Fixes #824