### PR TITLE
[9.x] Fix view-only permission not allowing read-only access to records

### DIFF
--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -158,7 +158,7 @@ class ResourceController extends CpController
             'blueprint' => $blueprint->toPublishArray(),
             'values' => $values,
             'meta' => $meta,
-            'readOnly' => $resource->readOnly(),
+            'readOnly' => $resource->readOnly() || User::current()->cant('edit', [$resource, $model]),
             'status' => $model->publishedStatus(),
             'permalink' => $resource->hasRouting() ? $model->uri() : null,
             'resourceHasRoutes' => $resource->hasRouting(),

--- a/src/Http/Requests/CP/EditRequest.php
+++ b/src/Http/Requests/CP/EditRequest.php
@@ -11,6 +11,6 @@ class EditRequest extends FormRequest
     {
         $model = $this->route('resource');
 
-        return User::current()->can('edit', [$model->runwayResource(), $model]);
+        return User::current()->can('view', [$model->runwayResource(), $model]);
     }
 }

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -18,7 +18,8 @@ class ResourcePolicy
 
     public function view($user, Resource $resource, $model = null)
     {
-        return User::fromUser($user)->hasPermission("view {$resource->handle()}");
+        return $this->edit($user, $resource, $model)
+            || User::fromUser($user)->hasPermission("view {$resource->handle()}");
     }
 
     public function create($user, Resource $resource)

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -394,6 +394,79 @@ class ResourceControllerTest extends TestCase
     }
 
     #[Test]
+    public function can_view_resource_in_read_only_mode_with_only_view_permission()
+    {
+        $post = Post::factory()->create();
+
+        Role::make('test')->addPermission('access cp')->addPermission('view post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'model' => $post->id]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('runway::Edit')
+                ->where('readOnly', true)
+            );
+    }
+
+    #[Test]
+    public function resource_is_not_read_only_when_user_has_edit_permission()
+    {
+        $post = Post::factory()->create();
+
+        Role::make('test')->addPermission('access cp')->addPermission('edit post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'model' => $post->id]))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('runway::Edit')
+                ->where('readOnly', false)
+            );
+    }
+
+    #[Test]
+    public function cant_edit_resource_without_view_permission()
+    {
+        $post = Post::factory()->create();
+
+        Role::make('test')->addPermission('access cp')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'model' => $post->id]))
+            ->assertRedirect();
+    }
+
+    #[Test]
+    public function cant_update_resource_with_only_view_permission()
+    {
+        $post = Post::factory()->create();
+
+        Role::make('test')->addPermission('access cp')->addPermission('view post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
+                'title' => 'Santa is coming home',
+                'slug' => 'santa-is-coming-home',
+                'body' => $post->body,
+                'author_id' => [$post->author_id],
+            ])
+            ->assertRedirect();
+
+        $post->refresh();
+
+        $this->assertNotSame($post->title, 'Santa is coming home');
+    }
+
+    #[Test]
     public function cant_edit_resource_when_it_does_not_exist()
     {
         $user = User::make()->makeSuper()->save();

--- a/tests/Policies/ResourcePolicyTest.php
+++ b/tests/Policies/ResourcePolicyTest.php
@@ -34,6 +34,28 @@ class ResourcePolicyTest extends TestCase
     }
 
     #[Test]
+    public function can_view_resource_with_only_edit_permission()
+    {
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('edit post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertTrue($user->can('view', $resource));
+    }
+
+    #[Test]
+    public function cant_view_resource_without_permission()
+    {
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertFalse($user->can('view', $resource));
+    }
+
+    #[Test]
     public function can_create_resource()
     {
         $resource = Runway::findResource('post');


### PR DESCRIPTION
This pull request fixes an issue where a user with only the *view* permission for a Runway resource could see the listing but got a "This action is unauthorized" error when clicking into an individual record.

This was happening because the edit screen authorized against the `edit` permission, rather than `view`. This differs from how entries work in Statamic core, where a view-only user can open an entry in read-only mode.

This PR fixes it by mirroring core's behaviour:

* `EditRequest` now authorizes `view` instead of `edit`, so view-only users can open a record. Saving still requires `edit` (via `UpdateRequest`), so they can't make changes.
* The edit screen's `readOnly` flag is now also `true` when the user can't `edit` the model, so the form renders in read-only mode (the "Read Only" badge shows and fields/save are disabled).
* `ResourcePolicy::view()` now returns `true` if the user can `edit`, matching core's `EntryPolicy::view()`.

Fixes #827