### PR TITLE
[9.x] Fix styling in revision history

### DIFF
--- a/resources/js/components/revision-history/Revision.vue
+++ b/resources/js/components/revision-history/Revision.vue
@@ -9,7 +9,7 @@
         :class="{
             'status-working-copy': revision.action === 'working',
             'status-published': revision.attributes.published,
-            'border border-ui-accent-bg dark:border-dark-ui-accent-bg/90 rounded-lg py-2.5 bg-[hsl(from_var(--theme-color-ui-accent-bg)_h_s_97)] dark:bg-[hsl(from_var(--theme-color-dark-ui-accent-bg)_h_40_20)]': revision.attributes.current,
+            'border border-ui-accent-bg dark:border-ui-accent-bg/90 rounded-lg py-2.5 bg-[hsl(from_var(--theme-color-ui-accent-bg)_h_s_97)] dark:bg-[hsl(from_var(--theme-color-ui-accent-bg)_h_40_20)]': revision.attributes.current,
             'bg-gradient-to-b from-transparent from-60% to-white dark:to-gray-800 -mt-1': isLast,
         }"
         v-tooltip="revision.attributes.current ? __('Current Revision') : null"


### PR DESCRIPTION
This PR fixes various styling issues in Runway's revision history. We needed to update Runway's `Revision.vue` component to keep its styles consistent with Core.

Fixes  #834