### PR TITLE
[9.x] Fix: default `initialItemActions` prop so PublishForm renders inside stacks

### DIFF
--- a/resources/js/components/PublishForm.vue
+++ b/resources/js/components/PublishForm.vue
@@ -326,8 +326,6 @@ export default {
         resourceHasRoutes: Boolean,
         livePreviewUrl: String,
         previewTargets: Array,
-        initialItemActions: { type: Array, default: () => [] },
-        itemActionUrl: String,
     },
 
     data() {

--- a/resources/js/components/PublishForm.vue
+++ b/resources/js/components/PublishForm.vue
@@ -326,7 +326,7 @@ export default {
         resourceHasRoutes: Boolean,
         livePreviewUrl: String,
         previewTargets: Array,
-        initialItemActions: Array,
+        initialItemActions: { type: Array, default: () => [] },
         itemActionUrl: String,
     },
 


### PR DESCRIPTION
## Problem

Opening a Runway resource **inside a stack** — e.g. clicking a related item from a `has_many` field on another resource — renders a broken publish form: the header bar never renders, so there is **no Save button**, and the following error is thrown in the console:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at Proxy.hasItemActions (…/statamic/cp/build/assets/index-….js)
    …
    at …/vendor/runway/build/assets/cp-….js
```

## Root cause

`PublishForm.vue` uses core's `HasActionsMixin`, which declares:

```js
initialItemActions: { type: Array, default: () => [] }
```

and a `hasItemActions` getter that reads `this.itemActions.length`.

However, `PublishForm.vue` **re-declares** the prop in its own `props` block without a default:

```js
initialItemActions: Array,
```

Because a component's own prop definition takes precedence over a mixin's, this wipes out the mixin's `default: () => []`. When the form is opened in a stack, the parent doesn't pass `initial-item-actions`, so `initialItemActions` is `undefined`. The mixin's `data()` sets `itemActions` from it, so `itemActions` is `undefined`, and `hasItemActions` throws when it accesses `.length` — aborting the render of the entire `<Header>`, including the Save button.

(The full-page editor works because the server passes `initialItemActions`, so the value is never `undefined` there.)

## Fix

Give the re-declared prop the same default the mixin had:

```diff
-        initialItemActions: Array,
+        initialItemActions: { type: Array, default: () => [] },
```

## Steps to reproduce

1. Two Eloquent-backed resources where one `hasMany` the other (e.g. `Instructor` → `ClassListing`).
2. On the parent's blueprint, add a `has_many` field pointing at the child resource.
3. Edit a parent record, open that tab, and click one of the related child items to open it in a stack.
4. **Before:** the stack opens with no Save button and the console shows the `hasItemActions` `TypeError`.
5. **After:** the stack renders correctly with a working Save button and no error.

## Testing

Verified locally against Statamic v6.24.2 + Runway v9.5.2 by rebuilding the CP assets with this change: the stack now renders the header/Save button and the console error is gone. Change is a single-line, backwards-compatible default (`+1/-1`).