### PR TITLE
[9.x] Add resources to the Link fieldtype

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/error-solutions": "^1.0 || ^2.0",
         "spatie/invade": "^2.1",
-        "statamic/cms": "^6.25",
+        "statamic/cms": "^6.26",
         "stillat/proteus": "^4.2.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "spatie/error-solutions": "^1.0 || ^2.0",
         "spatie/invade": "^2.1",
-        "statamic/cms": "^6.20",
+        "statamic/cms": "^6.25",
         "stillat/proteus": "^4.2.1"
     },
     "require-dev": {

--- a/src/ResourceLinkType.php
+++ b/src/ResourceLinkType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace StatamicRadPack\Runway;
+
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Link\LinkType;
+use Statamic\Support\Str;
+
+class ResourceLinkType extends LinkType
+{
+    const PREFIX = 'runway_';
+
+    public function title(): string
+    {
+        return $this->resource()->singular();
+    }
+
+    public function icon(): string
+    {
+        return $this->resource()->icon();
+    }
+
+    public function resolve(string $id, $parent = null, bool $localize = false): mixed
+    {
+        $resource = $this->resource();
+
+        return $resource->newEloquentQuery()->firstWhere($resource->qualifiedPrimaryKey(), $id);
+    }
+
+    public function fieldtype(Field $field): ?array
+    {
+        return [
+            'type' => 'belongs_to',
+            'resource' => $this->resource()->handle(),
+            'max_items' => 1,
+            'mode' => 'default',
+        ];
+    }
+
+    private function resource(): Resource
+    {
+        return Runway::findResource(Str::after($this->handle(), self::PREFIX));
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -21,6 +21,7 @@ use Statamic\Facades\CP\Nav;
 use Statamic\Facades\GraphQL;
 use Statamic\Facades\Permission;
 use Statamic\Facades\Search;
+use Statamic\Fieldtypes\Link;
 use Statamic\Http\Middleware\RequireStatamicPro;
 use Statamic\Listeners\UpdateAssetReferences;
 use Statamic\Listeners\UpdateTermReferences;
@@ -33,7 +34,6 @@ use StatamicRadPack\Runway\Policies\ResourcePolicy;
 use StatamicRadPack\Runway\Routing\RunwayUri;
 use StatamicRadPack\Runway\Search\Provider as SearchProvider;
 use StatamicRadPack\Runway\Search\Searchable;
-
 use function Illuminate\Events\queueable;
 
 class ServiceProvider extends AddonServiceProvider
@@ -73,6 +73,7 @@ class ServiceProvider extends AddonServiceProvider
                 ->registerPolicies()
                 ->registerNavigation()
                 ->registerBlueprints()
+                ->registerLinkTypes()
                 ->registerSearchProvider()
                 ->registerReferenceUpdaterHook()
                 ->bootGraphQl()
@@ -200,6 +201,16 @@ class ServiceProvider extends AddonServiceProvider
 
             Log::warning('Runway attempted to register its blueprint namespace. However, it seems the `blueprints` table has yet to be migrated.');
         }
+
+        return $this;
+    }
+
+    protected function registerLinkTypes(): self
+    {
+        Runway::allResources()
+            ->filter
+            ->hasRouting()
+            ->each(fn (Resource $resource) => Link::extend(ResourceLinkType::PREFIX.$resource->handle(), ResourceLinkType::class));
 
         return $this;
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,6 +34,7 @@ use StatamicRadPack\Runway\Policies\ResourcePolicy;
 use StatamicRadPack\Runway\Routing\RunwayUri;
 use StatamicRadPack\Runway\Search\Provider as SearchProvider;
 use StatamicRadPack\Runway\Search\Searchable;
+
 use function Illuminate\Events\queueable;
 
 class ServiceProvider extends AddonServiceProvider

--- a/tests/ResourceLinkTypeTest.php
+++ b/tests/ResourceLinkTypeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace StatamicRadPack\Runway\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Link;
+use Statamic\Routing\ResolveRedirect;
+use StatamicRadPack\Runway\ResourceLinkType;
+use StatamicRadPack\Runway\Runway;
+use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
+
+class ResourceLinkTypeTest extends TestCase
+{
+    #[Test]
+    public function it_registers_a_link_type_for_resources_with_routing()
+    {
+        $this->assertArrayHasKey('runway_post', Link::types());
+        $this->assertInstanceOf(ResourceLinkType::class, Link::types()['runway_post']);
+    }
+
+    #[Test]
+    public function it_doesnt_register_link_types_for_resources_without_routing()
+    {
+        $this->assertArrayNotHasKey('runway_author', Link::types());
+        $this->assertArrayNotHasKey('runway_user', Link::types());
+    }
+
+    #[Test]
+    public function its_title_is_the_resources_singular_name()
+    {
+        $this->assertEquals('Post', Link::resolveType('runway_post')->title());
+    }
+
+    #[Test]
+    public function its_icon_is_the_resources_icon()
+    {
+        $this->assertEquals(
+            Runway::findResource('post')->icon(),
+            Link::resolveType('runway_post')->icon()
+        );
+    }
+
+    #[Test]
+    public function it_returns_a_belongs_to_fieldtype_config()
+    {
+        $fieldtype = Link::resolveType('runway_post')->fieldtype(new Field('link', []));
+
+        $this->assertEquals([
+            'type' => 'belongs_to',
+            'resource' => 'post',
+            'max_items' => 1,
+            'mode' => 'default',
+        ], $fieldtype);
+    }
+
+    #[Test]
+    public function it_resolves_a_stored_id_to_its_model()
+    {
+        $post = Post::factory()->createQuietly();
+        $post->runwayUri()->create(['uri' => '/posts/'.$post->slug]);
+
+        $resolved = Link::resolveType('runway_post')->resolve($post->id);
+
+        $this->assertTrue($resolved->is($post));
+        $this->assertEquals('/posts/'.$post->slug, $resolved->url());
+    }
+
+    #[Test]
+    public function it_resolves_null_when_the_model_doesnt_exist()
+    {
+        $this->assertNull(Link::resolveType('runway_post')->resolve('does-not-exist'));
+    }
+
+    #[Test]
+    public function it_resolves_a_stored_value_to_a_url_via_resolve_redirect()
+    {
+        $post = Post::factory()->createQuietly();
+        $post->runwayUri()->create(['uri' => '/posts/'.$post->slug]);
+
+        $resolved = (new ResolveRedirect)("runway_post::{$post->id}", $post);
+
+        $this->assertEquals('/posts/'.$post->slug, $resolved);
+    }
+}


### PR DESCRIPTION
This pull request adds resources as options in Statamic's Link fieldtype. 

Depends on https://github.com/statamic/cms/pull/15004

## Screenshots

<img width="166" height="269" alt="CleanShot 2026-07-16 at 09 38 42" src="https://github.com/user-attachments/assets/1f0a2196-67b3-46ef-8344-5d632d1c1e90" />


<img width="985" height="92" alt="CleanShot 2026-07-16 at 09 38 16" src="https://github.com/user-attachments/assets/77efc53f-4230-486a-a66e-1776ac6d4707" />