### PR TITLE
[9.x] Batch relationship fieldtype augmentation into a single query

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -349,24 +349,33 @@ abstract class BaseFieldtype extends Relationship
 
     protected function getAugmentableModels(Resource $resource, $values): Collection
     {
-        return collect($values instanceof Collection ? $values : Arr::wrap($values))
-            ->map(function ($model) use ($resource) {
-                if (! $model instanceof Model) {
-                    $eagerLoadingRelationships = collect($this->config('with') ?? [])->join(',');
+        $values = $values instanceof Collection ? $values : Arr::wrap($values);
 
-                    return Blink::once("Runway::Model::{$this->config('resource')}_{$model}}::{$eagerLoadingRelationships}", function () use ($resource, $model) {
-                        return $resource->newEloquentQuery()
-                            ->when(
-                                $this->config('with'),
-                                fn ($query) => $query->with(Arr::wrap($this->config('with'))),
-                                fn ($query) => $query->with($resource->eagerLoadingRelationships())
-                            )
-                            ->firstWhere($resource->qualifiedPrimaryKey(), $model);
-                    });
-                }
+        $eagerLoadingRelationships = collect($this->config('with') ?? [])->join(',');
 
-                return $model;
-            })
+        $blinkKey = fn ($id) => "Runway::Model::{$this->config('resource')}_{$id}::{$eagerLoadingRelationships}";
+
+        // Only ids that haven't already been resolved (eg. by another field, or
+        // another instance of this field, earlier in the same request) need fetching.
+        $idsToFetch = collect($values)
+            ->reject(fn ($value) => $value instanceof Model)
+            ->reject(fn ($id) => Blink::has($blinkKey($id)))
+            ->values();
+
+        if ($idsToFetch->isNotEmpty()) {
+            $resource->newEloquentQuery()
+                ->when(
+                    $this->config('with'),
+                    fn ($query) => $query->with(Arr::wrap($this->config('with'))),
+                    fn ($query) => $query->with($resource->eagerLoadingRelationships())
+                )
+                ->whereIn($resource->qualifiedPrimaryKey(), $idsToFetch->all())
+                ->get()
+                ->each(fn ($model) => Blink::put($blinkKey($model->{$resource->primaryKey()}), $model));
+        }
+
+        return collect($values)
+            ->map(fn ($model) => $model instanceof Model ? $model : Blink::get($blinkKey($model)))
             ->when($resource->hasPublishStates(), fn ($collection) => $collection->filter(fn ($model) => $model?->published()))
             ->filter();
     }

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
@@ -301,6 +302,84 @@ class HasManyFieldtypeTest extends TestCase
 
         $this->assertEquals($posts[0]->id, $augment[0]['id']->value());
         $this->assertEquals($posts[0]->title, (string) $augment[0]['title']->value());
+    }
+
+    #[Test]
+    public function augmenting_multiple_ids_only_queries_the_database_once()
+    {
+        $author = Author::factory()->create();
+        $posts = Post::factory()->count(5)->create(['author_id' => $author->id]);
+
+        DB::enableQueryLog();
+
+        $this->fieldtype->augment(
+            $posts->pluck('id')->toArray()
+        );
+
+        $postQueries = collect(DB::getQueryLog())
+            ->filter(fn ($query) => str_contains($query['query'], 'posts'));
+
+        DB::disableQueryLog();
+
+        $this->assertCount(1, $postQueries);
+    }
+
+    #[Test]
+    public function augmenting_an_id_that_is_already_blink_cached_does_not_requery()
+    {
+        $author = Author::factory()->create();
+        $post = Post::factory()->create(['author_id' => $author->id]);
+
+        // Prime the Blink cache the same way an earlier field, or an earlier
+        // lookup of the same field, would have during the same request.
+        $this->fieldtype->augment([$post->id]);
+
+        DB::enableQueryLog();
+
+        $this->fieldtype->augment([$post->id]);
+
+        $postQueries = collect(DB::getQueryLog())
+            ->filter(fn ($query) => str_contains($query['query'], 'posts'));
+
+        DB::disableQueryLog();
+
+        $this->assertCount(0, $postQueries);
+    }
+
+    #[Test]
+    public function augmenting_ids_eager_loads_configured_relationships_without_extra_queries()
+    {
+        $author = Author::factory()->create();
+        $posts = Post::factory()->count(3)->create(['author_id' => $author->id]);
+
+        $this->fieldtype->setField(new Field('posts', [
+            'mode' => 'stack',
+            'resource' => 'post',
+            'display' => 'Posts',
+            'type' => 'has_many',
+            'with' => ['author'],
+        ]));
+
+        $getAugmentableModels = new \ReflectionMethod($this->fieldtype, 'getAugmentableModels');
+        $getAugmentableModels->setAccessible(true);
+
+        DB::enableQueryLog();
+
+        $models = $getAugmentableModels->invoke(
+            $this->fieldtype,
+            Runway::findResource('post'),
+            $posts->pluck('id')->toArray()
+        );
+
+        $queryCountAfterFetch = count(DB::getQueryLog());
+
+        // Accessing the eager-loaded relationship shouldn't trigger any further queries.
+        $models->each(fn ($post) => $post->author);
+
+        $this->assertCount($queryCountAfterFetch, DB::getQueryLog());
+        $this->assertTrue($models->first()->relationLoaded('author'));
+
+        DB::disableQueryLog();
     }
 
     #[Test]


### PR DESCRIPTION
BaseFieldtype::getAugmentableModels() resolved each id in a has_many/ relationship field one at a time via firstWhere(), so a field referencing N models triggered N queries (plus N more per eager-loaded relation) every time it was augmented for the front end.

Batch the ids that aren't already Blink-cached into a single whereIn()->with(...) query, populate Blink per-model afterwards, then read every value back out of Blink in original order. Blink caching behaviour (skipping ids already resolved elsewhere in the same request) and the with()/eagerLoadingRelationships() config are unchanged.