### PR TITLE
[9.x] Fix N+1 queries when augmenting relationships

### DIFF
--- a/src/Console/Commands/RebuildUriCache.php
+++ b/src/Console/Commands/RebuildUriCache.php
@@ -83,7 +83,7 @@ class RebuildUriCache extends Command
                     steps: $query->get(),
                     callback: function ($model) use ($resource) {
                         $uri = Antlers::parser()
-                            ->parse($resource->route(), $model->toAugmentedArray())
+                            ->parse($resource->route(), $model->toDeferredAugmentedArray())
                             ->__toString();
 
                         $uri = Str::start($uri, '/');

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -322,7 +322,7 @@ abstract class BaseFieldtype extends Relationship
         $results = $this->getAugmentableModels($resource, $values)
             ->map(function ($model) use ($resource) {
                 return Blink::once("Runway::FieldtypeAugment::{$resource->handle()}_{$model->{$resource->primaryKey()}}", function () use ($model) {
-                    return $model->toAugmentedArray();
+                    return $model->toDeferredAugmentedArray();
                 });
             });
 

--- a/src/Http/Resources/CP/FieldtypeModel.php
+++ b/src/Http/Resources/CP/FieldtypeModel.php
@@ -38,6 +38,6 @@ class FieldtypeModel extends JsonResource
             return $model->augmentedValue($firstListableColumn);
         }
 
-        return Parse::template($titleFormat, $model->toAugmentedArray());
+        return Parse::template($titleFormat, $model->toDeferredAugmentedArray());
     }
 }

--- a/src/Routing/Traits/RunwayRoutes.php
+++ b/src/Routing/Traits/RunwayRoutes.php
@@ -85,7 +85,7 @@ trait RunwayRoutes
             }
 
             $uri = Antlers::parser()
-                ->parse($resource->route(), $model->toAugmentedArray())
+                ->parse($resource->route(), $model->toDeferredAugmentedArray())
                 ->__toString();
 
             $uri = Str::start($uri, '/');

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -165,7 +165,7 @@ class RunwayTag extends Tags
         return collect($query)
             ->map(function ($model, $key) {
                 return Blink::once("Runway::Tag::AugmentModels::{$this->resource->handle()}::{$model->{$this->resource->primaryKey()}}", function () use ($model) {
-                    return $model->toAugmentedArray();
+                    return $model->toDeferredAugmentedArray();
                 });
             })
             ->toArray();

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -383,6 +383,35 @@ class HasManyFieldtypeTest extends TestCase
     }
 
     #[Test]
+    public function augmenting_defers_the_related_models_own_relationships()
+    {
+        $author = Author::factory()->create();
+        $posts = Post::factory()->count(3)->create(['author_id' => $author->id]);
+
+        $this->fieldtype->setField(new Field('posts', [
+            'mode' => 'stack',
+            'resource' => 'post',
+            'display' => 'Posts',
+            'type' => 'has_many',
+            'with' => ['runwayUri'],
+        ]));
+
+        DB::enableQueryLog();
+
+        $augment = $this->fieldtype->augment($posts->pluck('id')->toArray());
+
+        $authorQueries = collect(DB::getQueryLog())
+            ->filter(fn ($query) => str_contains($query['query'], 'from "authors"'));
+
+        $this->assertCount(0, $authorQueries);
+
+        // The relationship should still be resolvable, once something actually asks for it.
+        $this->assertEquals($author->id, $augment[0]['author_id']->value()['id']->value());
+
+        DB::disableQueryLog();
+    }
+
+    #[Test]
     public function can_get_item_data()
     {
         // Under the hood, this tests the toItemArray method.


### PR DESCRIPTION
This pull request fixes an issue where augmenting a relationship would trigger an N+1 query for each of the related models' own relationships.

This was happening because `toAugmentedArray` resolves every `Value` up-front. For most Statamic data that's cheap, since resolving a relationship just returns the raw IDs. In Runway, the raw value of a relationship is `$model->getAttribute($handle)`, which lazy loads it. So augmenting a `has_many` field queried every relationship on every related model, whether or not the template used them.

This PR fixes it by using `toDeferredAugmentedArray` instead, so each `Value` is only resolved when something actually asks for it. This is the same thing Statamic does when hydrating the cascade.

This PR also swaps out the same pattern in a few other places which augment a whole model just to use one or two keys:

* The `{{ runway }}` tag.
* URI generation (both on save and in `runway:rebuild-uri-cache`), which was loading every relationship just to parse `/posts/{{ slug }}`.
* `title_format` on the relationship fieldtypes.

Fixes #777