### PR TITLE
[9.x] Fix N+1 queries when augmenting relationships inside nested fields

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
+use Statamic\Contracts\Data\Augmentable;
 use Statamic\CP\Column;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Scope;
@@ -363,6 +364,14 @@ abstract class BaseFieldtype extends Relationship
             ->values();
 
         if ($idsToFetch->isNotEmpty()) {
+            // Sets in a replicator (or rows in a grid, etc.) are augmented one at a time, so
+            // fetch the ids used by the sibling sets too, rather than querying for each one.
+            $idsToFetch = $idsToFetch
+                ->merge($this->siblingIds())
+                ->reject(fn ($id) => Blink::has($blinkKey($id)))
+                ->unique()
+                ->values();
+
             $resource->newEloquentQuery()
                 ->when(
                     $this->config('with'),
@@ -378,6 +387,29 @@ abstract class BaseFieldtype extends Relationship
             ->map(fn ($model) => $model instanceof Model ? $model : Blink::get($blinkKey($model)))
             ->when($resource->hasPublishStates(), fn ($collection) => $collection->filter(fn ($model) => $model?->published()))
             ->filter();
+    }
+
+    private function siblingIds(): Collection
+    {
+        $field = $this->field;
+        $parent = $field?->parent();
+
+        if (! $field?->parentField() || ! $parent instanceof Augmentable) {
+            return collect();
+        }
+
+        [$rootHandle] = $field->handlePath();
+        $handle = $field->handle();
+
+        $ids = function ($value) use (&$ids, $handle) {
+            return collect($value)->flatMap(fn ($item, $key) => match (true) {
+                $key === $handle => collect(Arr::wrap($item))->filter(fn ($id) => is_string($id) || is_int($id)),
+                is_array($item) => $ids($item),
+                default => [],
+            });
+        };
+
+        return $ids($parent->augmentedValue($rootHandle)->raw())->unique()->values();
     }
 
     protected function getColumns()

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -6,11 +6,15 @@ use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
+use Statamic\Facades\Collection as CollectionFacade;
+use Statamic\Facades\Entry;
 use Statamic\Facades\User;
 use Statamic\Fields\Field;
 use Statamic\Http\Requests\FilteredRequest;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use StatamicRadPack\Runway\Fieldtypes\BelongsToFieldtype;
 use StatamicRadPack\Runway\Runway;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Author;
@@ -19,7 +23,7 @@ use StatamicRadPack\Runway\Tests\TestCase;
 
 class BelongsToFieldtypeTest extends TestCase
 {
-    use WithFaker;
+    use PreventsSavingStacheItemsToDisk, WithFaker;
 
     protected BelongsToFieldtype $fieldtype;
 
@@ -262,6 +266,66 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertIsArray($augment);
         $this->assertEquals($author->id, $augment['id']->value());
         $this->assertEquals($author->name, $augment['name']->value());
+    }
+
+    #[Test]
+    public function augmenting_replicator_sets_only_queries_the_database_once()
+    {
+        CollectionFacade::make('pages')->save();
+
+        $authors = Author::factory()->count(5)->create();
+
+        $entry = Entry::make()->collection('pages')->slug('test')->data([
+            'tooltips' => $authors->map(fn ($author, $index) => [
+                'id' => "set-{$index}",
+                'type' => 'tooltip',
+                'author' => $author->id,
+            ])->all(),
+        ]);
+
+        DB::enableQueryLog();
+
+        foreach ($entry->augmentedValue('tooltips')->value() as $tooltip) {
+            $tooltip['author'];
+        }
+
+        $authorQueries = collect(DB::getQueryLog())
+            ->filter(fn ($query) => str_contains($query['query'], 'authors'));
+
+        DB::disableQueryLog();
+
+        $this->assertCount(1, $authorQueries);
+    }
+
+    #[Test]
+    public function augmenting_grid_rows_nested_in_replicator_sets_only_queries_the_database_once()
+    {
+        CollectionFacade::make('pages')->save();
+
+        $authors = Author::factory()->count(5)->create();
+
+        $entry = Entry::make()->collection('pages')->slug('test')->data([
+            'tooltips' => $authors->map(fn ($author, $index) => [
+                'id' => "set-{$index}",
+                'type' => 'tooltip',
+                'rows' => [['id' => "row-{$index}", 'author' => $author->id]],
+            ])->all(),
+        ]);
+
+        DB::enableQueryLog();
+
+        foreach ($entry->augmentedValue('tooltips')->value() as $tooltip) {
+            foreach ($tooltip['rows'] as $row) {
+                $row['author'];
+            }
+        }
+
+        $authorQueries = collect(DB::getQueryLog())
+            ->filter(fn ($query) => str_contains($query['query'], 'authors'));
+
+        DB::disableQueryLog();
+
+        $this->assertCount(1, $authorQueries);
     }
 
     #[Test]

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -325,6 +325,36 @@ class HasManyFieldtypeTest extends TestCase
     }
 
     #[Test]
+    public function augmenting_replicator_sets_only_queries_the_database_once()
+    {
+        \Statamic\Facades\Collection::make('pages')->save();
+
+        $author = Author::factory()->create();
+        $posts = Post::factory()->count(6)->create(['author_id' => $author->id]);
+
+        $entry = Entry::make()->collection('pages')->slug('test')->data([
+            'tooltips' => $posts->chunk(2)->values()->map(fn ($chunk, $index) => [
+                'id' => "set-{$index}",
+                'type' => 'tooltip',
+                'posts' => $chunk->pluck('id')->all(),
+            ])->all(),
+        ]);
+
+        DB::enableQueryLog();
+
+        foreach ($entry->augmentedValue('tooltips')->value() as $tooltip) {
+            $tooltip['posts'];
+        }
+
+        $postQueries = collect(DB::getQueryLog())
+            ->filter(fn ($query) => str_contains($query['query'], 'posts'));
+
+        DB::disableQueryLog();
+
+        $this->assertCount(1, $postQueries);
+    }
+
+    #[Test]
     public function augmenting_an_id_that_is_already_blink_cached_does_not_requery()
     {
         $author = Author::factory()->create();

--- a/tests/__fixtures__/resources/blueprints/collections/pages/pages.yaml
+++ b/tests/__fixtures__/resources/blueprints/collections/pages/pages.yaml
@@ -1,0 +1,36 @@
+tabs:
+  main:
+    sections:
+      -
+        fields:
+          -
+            handle: tooltips
+            field:
+              type: replicator
+              sets:
+                main:
+                  sets:
+                    tooltip:
+                      fields:
+                        -
+                          handle: author
+                          field:
+                            type: belongs_to
+                            resource: author
+                            max_items: 1
+                        -
+                          handle: posts
+                          field:
+                            type: has_many
+                            resource: post
+                        -
+                          handle: rows
+                          field:
+                            type: grid
+                            fields:
+                              -
+                                handle: author
+                                field:
+                                  type: belongs_to
+                                  resource: author
+                                  max_items: 1


### PR DESCRIPTION
This pull request fixes an issue where a relationship field nested inside a replicator, grid or Bard field would trigger a separate query for every set.

This was happening because Statamic augments each set’s fields independently. #840 batched the IDs within a single `augment()` call, but a `belongs_to` inside a replicator only ever has one ID per set, so every set still ended up querying on its own.

This PR fixes it by looking at the field’s siblings when it’s nested. Runway reads the raw value of the outermost ancestor field off the parent, collects every ID stored under the same handle across all the sets/rows, and folds them into the same `whereIn` query. Augmenting the first set now warms the Blink cache for all the rest.

It works for replicator, grid, Bard and group fields, at any nesting depth, and whether the parent is an entry, global, term or another Runway model.

Related: #847
Related: #843