### PR TITLE
[9.x] Configuration option disable static warm

### DIFF
--- a/config/runway.php
+++ b/config/runway.php
@@ -42,7 +42,6 @@ return [
 
     'disable_migrations' => false,
 
-
     /*
     |--------------------------------------------------------------------------
     | Disable Static Warm?

--- a/config/runway.php
+++ b/config/runway.php
@@ -47,7 +47,7 @@ return [
     | Static Warming
     |--------------------------------------------------------------------------
     |
-    | Should Runway's URIs be included when running `php please static:warm`?
+    | Should Runway's URIs be warmed when running `php please static:warm`?
     |
     */
 

--- a/config/runway.php
+++ b/config/runway.php
@@ -42,4 +42,16 @@ return [
 
     'disable_migrations' => false,
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Disable Static Warm?
+    |--------------------------------------------------------------------------
+    |
+    | Should Runway's uris be automatically warmed when running `php please static:warm`
+    |
+    */
+
+    'disable_static_warm' => false,
+
 ];

--- a/config/runway.php
+++ b/config/runway.php
@@ -44,13 +44,13 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Disable Static Warm?
+    | Static Warming
     |--------------------------------------------------------------------------
     |
-    | Should Runway's uris be automatically warmed when running `php please static:warm`
+    | Should Runway's URIs be included when running `php please static:warm`?
     |
     */
 
-    'disable_static_warm' => false,
+    'static_warming' => true,
 
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -314,7 +314,7 @@ class ServiceProvider extends AddonServiceProvider
             $this->app->get(\Statamic\Contracts\Data\DataRepository::class)
                 ->setRepository('runway', ModelRepository::class);
 
-            if (! config('runway.disable_static_warm')) {
+            if (config('runway.static_warming', true)) {
                 StaticWarm::hook('additional', function ($urls, $next) {
                     return $next($urls->merge(RunwayUri::select('uri')->pluck('uri')->all()));
                 });

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -314,9 +314,11 @@ class ServiceProvider extends AddonServiceProvider
             $this->app->get(\Statamic\Contracts\Data\DataRepository::class)
                 ->setRepository('runway', ModelRepository::class);
 
-            StaticWarm::hook('additional', function ($urls, $next) {
-                return $next($urls->merge(RunwayUri::select('uri')->pluck('uri')->all()));
-            });
+            if (! config('runway.disable_static_warm')) {
+                StaticWarm::hook('additional', function ($urls, $next) {
+                    return $next($urls->merge(RunwayUri::select('uri')->pluck('uri')->all()));
+                });
+            }
         }
 
         return $this;


### PR DESCRIPTION
This pull request adds a configuration option to disable warming of runway's uris.

When using Statamic's [warming additional URLs](https://statamic.dev/advanced-topics/static-caching#warming-additional-urls) feature, developers may want complete control over which URLs are warmed. This option allows Runway URI warming to be disabled, preventing possible overlap with custom warming configurations and enabling fully customized cache warming strategies.