### PR TITLE
[9.x] Implement `runwayLinkFieldtype` query scope

### DIFF
--- a/docs/frontend-routing.mdx
+++ b/docs/frontend-routing.mdx
@@ -120,6 +120,27 @@ By default, Runway will use the `runway_uris` table to store the "URI Cache". If
 ```
 
 
+## Link fieldtype
+
+Resources with front-end routing are available as options in Statamic's [Link fieldtype](https://statamic.dev/fieldtypes/link), allowing you to link to your models from entries and other content.
+
+If you need to change which models can be linked to, you may add a `runwayLinks` query scope to your model:
+
+```php focus={7-11}
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    #[Scope]
+	protected function runwayLinks(Builder $query): void
+	{
+		$query->where('is_active', true);
+	}
+}
+```
+
 ## Live Preview
 Statamic's Live Preview gives you the ability to see what your model will look like in real time as you write and edit.
 

--- a/docs/frontend-routing.mdx
+++ b/docs/frontend-routing.mdx
@@ -124,7 +124,7 @@ By default, Runway will use the `runway_uris` table to store the "URI Cache". If
 
 Resources with front-end routing are available as options in Statamic's [Link fieldtype](https://statamic.dev/fieldtypes/link), allowing you to link to your models from entries and other content.
 
-If you need to change which models can be linked to, you may add a `runwayLinks` query scope to your model:
+If you need to change which models can be linked to, you may add a `runwayLinkFieldtype` query scope to your model:
 
 ```php focus={7-11}
 use Illuminate\Database\Eloquent\Attributes\Scope;
@@ -134,7 +134,7 @@ use Illuminate\Database\Eloquent\Model;
 class Product extends Model
 {
     #[Scope]
-	protected function runwayLinks(Builder $query): void
+	protected function runwayLinkFieldtype(Builder $query): void
 	{
 		$query->where('is_active', true);
 	}

--- a/src/ResourceLinkType.php
+++ b/src/ResourceLinkType.php
@@ -24,7 +24,12 @@ class ResourceLinkType extends LinkType
     {
         $resource = $this->resource();
 
-        return $resource->newEloquentQuery()->firstWhere($resource->qualifiedPrimaryKey(), $id);
+        return $resource->newEloquentQuery()
+            ->when(
+                $resource->model()->hasNamedScope('runwayLinks'),
+                fn ($query) => $query->runwayLinks()
+            )
+            ->firstWhere($resource->qualifiedPrimaryKey(), $id);
     }
 
     public function fieldtype(Field $field): ?array

--- a/src/ResourceLinkType.php
+++ b/src/ResourceLinkType.php
@@ -26,8 +26,8 @@ class ResourceLinkType extends LinkType
 
         return $resource->newEloquentQuery()
             ->when(
-                $resource->model()->hasNamedScope('runwayLinks'),
-                fn ($query) => $query->runwayLinks()
+                $resource->model()->hasNamedScope('runwayLinkFieldtype'),
+                fn ($query) => $query->runwayLinkFieldtype()
             )
             ->firstWhere($resource->qualifiedPrimaryKey(), $id);
     }

--- a/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
+++ b/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
@@ -10,20 +10,16 @@ use StatamicRadPack\Runway\Tests\TestCase;
 
 class PublishedModelsControllerTest extends TestCase
 {
-    private $dir;
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->dir = __DIR__.'/tmp';
         config(['statamic.revisions.enabled' => true]);
-        config(['statamic.revisions.path' => $this->dir]);
     }
 
     protected function tearDown(): void
     {
-        Folder::delete($this->dir);
+        Folder::delete(__DIR__.'/../../../__fixtures__/revisions');
 
         parent::tearDown();
     }

--- a/tests/ResourceLinkTypeTest.php
+++ b/tests/ResourceLinkTypeTest.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Runway\Tests;
 
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blink;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Link;
 use Statamic\Routing\ResolveRedirect;
@@ -70,6 +71,18 @@ class ResourceLinkTypeTest extends TestCase
     public function it_resolves_null_when_the_model_doesnt_exist()
     {
         $this->assertNull(Link::resolveType('runway_post')->resolve('does-not-exist'));
+    }
+
+    #[Test]
+    public function it_applies_the_runway_links_scope_when_resolving()
+    {
+        $published = Post::factory()->createQuietly();
+        $unpublished = Post::factory()->unpublished()->createQuietly();
+
+        Blink::put('RunwayLinksScopeWhere', ['published', true]);
+
+        $this->assertTrue(Link::resolveType('runway_post')->resolve($published->id)->is($published));
+        $this->assertNull(Link::resolveType('runway_post')->resolve($unpublished->id));
     }
 
     #[Test]

--- a/tests/ResourceLinkTypeTest.php
+++ b/tests/ResourceLinkTypeTest.php
@@ -74,12 +74,12 @@ class ResourceLinkTypeTest extends TestCase
     }
 
     #[Test]
-    public function it_applies_the_runway_links_scope_when_resolving()
+    public function it_applies_the_runway_link_fieldtype_scope_when_resolving()
     {
         $published = Post::factory()->createQuietly();
         $unpublished = Post::factory()->unpublished()->createQuietly();
 
-        Blink::put('RunwayLinksScopeWhere', ['published', true]);
+        Blink::put('RunwayLinkFieldtypeScopeWhere', ['published', true]);
 
         $this->assertTrue(Link::resolveType('runway_post')->resolve($published->id)->is($published));
         $this->assertNull(Link::resolveType('runway_post')->resolve($unpublished->id));

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -50,9 +50,9 @@ class Post extends Model
         }
     }
 
-    public function scopeRunwayLinks($query)
+    public function scopeRunwayLinkFieldtype($query)
     {
-        if ($params = Blink::get('RunwayLinksScopeWhere')) {
+        if ($params = Blink::get('RunwayLinkFieldtypeScopeWhere')) {
             $query->where($params[0], $params[1]);
         }
     }

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -50,6 +50,13 @@ class Post extends Model
         }
     }
 
+    public function scopeRunwayLinks($query)
+    {
+        if ($params = Blink::get('RunwayLinksScopeWhere')) {
+            $query->where($params[0], $params[1]);
+        }
+    }
+
     public function author()
     {
         return $this->belongsTo(Author::class);


### PR DESCRIPTION
This pull request implements support for a `runwayLinkFieldtype` query scope, which is applied when resolving a model from the Link fieldtype.

If you need to change which models can be linked to, you may add a `runwayLinkFieldtype` query scope to your model:

```php
use Illuminate\Database\Eloquent\Attributes\Scope;
use Illuminate\Database\Eloquent\Builder;
use Illuminate\Database\Eloquent\Model;

class Product extends Model
{
    #[Scope]
    protected function runwayLinkFieldtype(Builder $query): void
    {
        $query->where('is_active', true);
    }
}
```

This works in the same way as the existing `runwayListing` and `runwayRoutes` scopes.

This PR also fixes `PublishedModelsControllerTest` leaving revisions behind in `tests/__fixtures__/revisions`. This was happening because it was overriding `statamic.revisions.path`, but revisions are now written via the Stache store, whose directory is configured in `TestCase`. I've fixed it by deleting the fixtures directory on tear down, like the other revision tests do.

Related: #849
