### PR TITLE
[9.x] Clean up revisions left behind by PublishedModelsControllerTest

### DIFF
--- a/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
+++ b/tests/Http/Controllers/CP/PublishedModelsControllerTest.php
@@ -10,20 +10,16 @@ use StatamicRadPack\Runway\Tests\TestCase;
 
 class PublishedModelsControllerTest extends TestCase
 {
-    private $dir;
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->dir = __DIR__.'/tmp';
         config(['statamic.revisions.enabled' => true]);
-        config(['statamic.revisions.path' => $this->dir]);
     }
 
     protected function tearDown(): void
     {
-        Folder::delete($this->dir);
+        Folder::delete(__DIR__.'/../../../__fixtures__/revisions');
 
         parent::tearDown();
     }


### PR DESCRIPTION
This pull request fixes an issue where `PublishedModelsControllerTest` left revision files behind in `tests/__fixtures__/revisions` after running.

This was happening because the test overrides `statamic.revisions.path` and deletes that directory on tear down, but revisions are now written via the Stache store, whose directory is configured in `TestCase` to point at the fixtures directory.

This PR fixes it by deleting the fixtures directory on tear down, like `ModelRevisionsControllerTest` and `RestoreModelRevisionController` already do.