### PR TITLE
[9.x] Orderable resources

### DIFF
--- a/config/runway.php
+++ b/config/runway.php
@@ -19,28 +19,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Runway URIs Table
-    |--------------------------------------------------------------------------
-    |
-    | When using Runway's front-end routing functionality, Runway will store model
-    | URIs in a table to enable easy "URI -> model" lookups. If needed, you can
-    | customize the table name here.
-    |
-    */
-
-    'uris_table' => 'runway_uris',
-
-    /*
-    |--------------------------------------------------------------------------
     | Disable Migrations?
     |--------------------------------------------------------------------------
     |
-    | Should Runway's migrations be disabled?
-    | (eg. not automatically run when you next vendor:publish)
+    | Runway publishes migrations to power various optional features. If
+    | you're not using those features, you may disable their migrations here.
     |
     */
 
     'disable_migrations' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tables
+    |--------------------------------------------------------------------------
+    |
+    | Runway stores model URIs (for front-end routing) and the order of models
+    | (for reorderable resources) in its own tables. You may customize the
+    | table names here, if needed.
+    |
+    */
+
+    'tables' => [
+        'uris' => 'runway_uris',
+        'structures' => 'runway_structures',
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2021_05_04_162552_create_runway_uris_table.php
+++ b/database/migrations/2021_05_04_162552_create_runway_uris_table.php
@@ -13,7 +13,7 @@ class CreateRunwayUrisTable extends Migration
      */
     public function up()
     {
-        Schema::create(config('runway.uris_table', 'runway_uris'), function (Blueprint $table) {
+        Schema::create(config('runway.uris_table') ?? config('runway.tables.uris', 'runway_uris'), function (Blueprint $table) {
             $table->id();
             $table->string('uri');
             $table->string('model_type');
@@ -29,6 +29,6 @@ class CreateRunwayUrisTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists(config('runway.uris_table', 'runway_uris'));
+        Schema::dropIfExists(config('runway.uris_table') ?? config('runway.tables.uris', 'runway_uris'));
     }
 }

--- a/database/migrations/2026_09_04_000000_create_runway_structures_table.php
+++ b/database/migrations/2026_09_04_000000_create_runway_structures_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create(config('runway.tables.structures', 'runway_structures'), function (Blueprint $table) {
+            $table->id();
+            $table->string('model_type');
+            $table->string('model_id', 36);
+            $table->unsignedInteger('order');
+            $table->timestamps();
+
+            $table->unique(['model_type', 'model_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists(config('runway.tables.structures', 'runway_structures'));
+    }
+};

--- a/docs/control-panel.mdx
+++ b/docs/control-panel.mdx
@@ -39,6 +39,7 @@ You may customize permission labels by adding a `resources/lang/{lang}/runway.ph
     'create' => 'Criar :resource',
     'delete' => 'Excluir :resource',
     'edit' => 'Editar :resource',
+    'reorder' => 'Reordenar :resource',
     'view' => 'Visualizar :resource'
 ]
 ```

--- a/docs/frontend-routing.mdx
+++ b/docs/frontend-routing.mdx
@@ -105,18 +105,10 @@ class Product extends Model
 By default, Runway will use the `runway_uris` table to store the "URI Cache". If you wish to change the name of the table, you may do so in the `runway.php` configuration file:
 
 ```php
-/*
-|--------------------------------------------------------------------------
-| Runway URIs Table
-|--------------------------------------------------------------------------
-|
-| When using Runway's front-end routing functionality, Runway will store model
-| URIs in a table to enable easy "URI -> model" lookups. If needed, you can
-| customize the table name here.
-|
-*/
-
-'uris_table' => 'runway_uris',
+'tables' => [
+    'uris' => 'runway_uris',
+    'structures' => 'runway_structures',
+],
 ```
 
 

--- a/docs/resources.mdx
+++ b/docs/resources.mdx
@@ -139,6 +139,33 @@ Sometimes you may want to change the order that your models are returned in the 
 ],
 ```
 
+### Reordering
+
+If you'd rather arrange models by hand, you can make a resource "orderable". Much like an orderable collection, users can drag & drop models into the order they want in the Control Panel listing.
+
+```php
+'resources' => [
+	\App\Models\Manufacturer::class => [
+	    'name' => 'Manufacturers',
+        'orderable' => true,
+	],
+],
+```
+
+Runway keeps track of the order in its own `runway_structures` table, so you don't need to add a column to your model's table. Make sure you've run `php artisan migrate` after updating Runway. If you wish to change the name of the table, you may do so via the `tables.structures` option in the `runway.php` configuration file.
+
+<Note>
+If you've set `disable_migrations` to `true` in your `runway.php` configuration file, Runway won't run this migration for you. You'll need to create the `runway_structures` table yourself, using [Runway's migration](https://github.com/statamic-rad-pack/runway/blob/9.x/database/migrations/2026_09_04_000000_create_runway_structures_table.php) as a reference.
+</Note>
+
+When a resource is orderable, the `order_by` and `order_by_direction` options are ignored. Models will be returned in the manually defined order by the Control Panel listing, the `{{ runway }}` tag and the GraphQL API. You can also sort by `order` explicitly:
+
+```antlers
+{{ runway:manufacturer sort="order:desc" }}
+```
+
+Users need the "Reorder" permission for the resource to be able to change the order. Models created before a resource was made orderable, or created outside of Runway, are placed at the end of the list until the order is next saved.
+
 ### Title field
 
 When Runway displays models inside inside the Control Panel (eg. in relationship fields, in search), it'll default to showing the first listable field it can find, based on your blueprint.

--- a/resources/js/pages/Index.vue
+++ b/resources/js/pages/Index.vue
@@ -12,7 +12,7 @@ import {
     Listing,
     StatusIndicator,
 } from '@statamic/cms/ui'
-import { ref } from 'vue';
+import { getCurrentInstance, onBeforeUnmount, onMounted, ref } from 'vue';
 
 const props = defineProps({
     icon: { type: String, required: true },
@@ -32,19 +32,59 @@ const props = defineProps({
     canEditBlueprint: { type: Boolean, required: true },
     hasPublishStates: { type: Boolean, required: true },
     titleColumn: { type: String, required: true },
+    reorderable: { type: Boolean, required: true },
+    reorderUrl: { type: String, required: true },
 });
+
+const { $axios, $toast, $keys } = getCurrentInstance().appContext.config.globalProperties;
 
 const preferencesPrefix = ref(`runway.${props.resource}`);
 const requestUrl = ref(cp_url(`runway/${props.resource}/listing-api`));
 const items = ref(null);
 const page = ref(null);
 const perPage = ref(null);
+const reordering = ref(false);
+
+let saveKeyBinding = null;
 
 function requestComplete({ items: newItems, parameters }) {
     items.value = newItems;
     page.value = parameters.page;
     perPage.value = parameters.perPage;
 }
+
+function reordered(newItems) {
+    items.value = newItems;
+}
+
+function saveOrder() {
+    const payload = {
+        ids: items.value.map((item) => item.id),
+        page: page.value,
+        perPage: perPage.value,
+    };
+
+    $axios
+        .post(props.reorderUrl, payload)
+        .then(() => {
+            reordering.value = false;
+            $toast.success(__('Order saved'));
+        })
+        .catch((e) => {
+            $toast.error(e.response?.data?.message || __('Something went wrong'));
+        });
+}
+
+onMounted(() => {
+    saveKeyBinding = $keys.bindGlobal(['mod+s'], (e) => {
+        if (reordering.value) {
+            e.preventDefault();
+            saveOrder();
+        }
+    });
+});
+
+onBeforeUnmount(() => saveKeyBinding.destroy());
 </script>
 
 <template>
@@ -80,7 +120,16 @@ function requestComplete({ items: newItems, parameters }) {
                 </Dropdown>
             </ItemActions>
 
-            <Button v-if="canCreate" variant="primary" :text="createLabel" :href="createUrl" />
+            <template v-if="reorderable">
+                <Button v-if="!reordering" :text="__('Reorder')" @click="reordering = true" />
+
+                <template v-if="reordering">
+                    <Button :text="__('Cancel')" @click="reordering = false" />
+                    <Button variant="primary" :text="__('Save Order')" @click="saveOrder" />
+                </template>
+            </template>
+
+            <Button v-if="canCreate && !reordering" variant="primary" :text="createLabel" :href="createUrl" />
         </Header>
 
         <Listing
@@ -93,8 +142,10 @@ function requestComplete({ items: newItems, parameters }) {
             :action-context="{ resource }"
             :preferences-prefix
             :filters
+            :reorderable="reordering"
             push-query
             @request-completed="requestComplete"
+            @reordered="reordered"
         >
             <template v-slot:[`cell-${titleColumn}`]="{ row: model, isColumnVisible }">
                 <Link class="title-index-field" :href="model.edit_url" @click.stop>

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -5,6 +5,7 @@ use StatamicRadPack\Runway\Http\Controllers\CP\ModelActionController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ModelPreviewController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ModelRevisionsController;
 use StatamicRadPack\Runway\Http\Controllers\CP\PublishedModelsController;
+use StatamicRadPack\Runway\Http\Controllers\CP\ReorderModelsController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ResourceActionController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ResourceController;
 use StatamicRadPack\Runway\Http\Controllers\CP\ResourceListingController;
@@ -15,6 +16,7 @@ Route::name('runway.')->prefix('runway')->group(function () {
     Route::get('{resource}/listing-api', [ResourceListingController::class, 'index'])->name('listing-api');
 
     Route::post('{resource}/actions', [ResourceActionController::class, 'run'])->name('actions.run');
+    Route::post('{resource}/reorder', ReorderModelsController::class)->name('reorder');
 
     Route::post('{resource}/models/actions', [ModelActionController::class, 'runAction'])->name('models.actions.run');
     Route::post('{resource}/models/actions/list', [ModelActionController::class, 'bulkActionsList'])->name('models.actions.bulk');

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -216,7 +216,15 @@ abstract class BaseFieldtype extends Relationship
                     $query->reorder($this->resource()->model()->getFieldColumn($sortColumn), $request->input('order'));
                 }
             }
-        }, fn ($query) => $query->orderBy($this->resource()->orderBy(), $this->resource()->orderByDirection()));
+        }, function ($query) {
+            if ($query instanceof Builder) {
+                $query->runwayOrderBy($this->resource()->orderBy(), $this->resource()->orderByDirection());
+
+                return;
+            }
+
+            $query->orderBy($this->resource()->orderBy(), $this->resource()->orderByDirection());
+        });
     }
 
     protected function getIndexQuery(FilteredRequest $request): Builder|SearchQueryBuilder

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -66,7 +66,7 @@ class ResourceIndexQuery extends Query
     protected function sortQuery($query, $sorts): void
     {
         if (empty($sorts)) {
-            $sorts = ['id'];
+            $sorts = ["{$this->resource->orderBy()} {$this->resource->orderByDirection()}"];
         }
 
         foreach ($sorts as $sort) {
@@ -77,7 +77,7 @@ class ResourceIndexQuery extends Query
             }
 
             if ($sort = OrderBy::column($sort)) {
-                $query = $query->orderBy($sort, $order);
+                $query->runwayOrderBy($sort, $order);
             }
         }
     }

--- a/src/Http/Controllers/CP/ReorderModelsController.php
+++ b/src/Http/Controllers/CP/ReorderModelsController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace StatamicRadPack\Runway\Http\Controllers\CP;
+
+use Illuminate\Http\Request;
+use Statamic\Http\Controllers\CP\CpController;
+use StatamicRadPack\Runway\Resource;
+use StatamicRadPack\Runway\Structures\RunwayStructure;
+
+class ReorderModelsController extends CpController
+{
+    public function __invoke(Request $request, Resource $resource)
+    {
+        abort_unless($resource->orderable(), 404);
+
+        $this->authorize('reorder', $resource);
+
+        $request->validate([
+            'ids' => 'required|array',
+            'page' => 'required|integer',
+            'perPage' => 'required|integer',
+        ]);
+
+        $ids = $resource->newEloquentQuery()
+            ->when($resource->model()->hasNamedScope('runwayListing'), fn ($query) => $query->runwayListing())
+            ->runwayOrderBy('order')
+            ->toBase()
+            ->pluck($resource->qualifiedPrimaryKey())
+            ->map(fn ($id) => (string) $id);
+
+        $offset = ($request->page - 1) * $request->perPage;
+
+        $submitted = collect($request->ids)->map(fn ($id) => (string) $id);
+        $current = $ids->slice($offset, $request->perPage);
+
+        // If the submitted ids aren't a rearrangement of the page being reordered, the
+        // listing was out of date. Continuing would duplicate and drop models.
+        if ($submitted->sort()->values()->all() !== $current->sort()->values()->all()) {
+            abort(409, __('The listing is out of date. Refresh the page and try reordering again.'));
+        }
+
+        $reordered = $ids->values()->all();
+
+        foreach ($submitted as $index => $id) {
+            $reordered[$offset + $index] = $id;
+        }
+
+        $modelType = $resource->model()->getMorphClass();
+
+        $existing = RunwayStructure::query()
+            ->where('model_type', $modelType)
+            ->pluck('order', 'model_id');
+
+        $rows = collect($reordered)
+            ->map(fn ($id, $index) => ['model_type' => $modelType, 'model_id' => $id, 'order' => $index + 1])
+            ->reject(fn ($row) => (int) $existing->get($row['model_id']) === $row['order'])
+            ->values()
+            ->all();
+
+        RunwayStructure::upsert($rows, ['model_type', 'model_id'], ['order']);
+    }
+}

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -58,6 +58,8 @@ class ResourceController extends CpController
             'canEditBlueprint' => User::current()->can('configure fields'),
             'hasPublishStates' => $resource->hasPublishStates(),
             'titleColumn' => $this->getTitleColumn($resource),
+            'reorderable' => $resource->orderable() && User::current()->can('reorder', $resource),
+            'reorderUrl' => cp_route('runway.reorder', ['resource' => $resource->handle()]),
         ]);
     }
 

--- a/src/Http/Controllers/CP/ResourceListingController.php
+++ b/src/Http/Controllers/CP/ResourceListingController.php
@@ -33,12 +33,13 @@ class ResourceListingController extends CpController
         $query = $this->applySearch($resource, $query, $searchQuery);
 
         $sortColumn = OrderBy::column($request->input('sort'), $resource->orderBy());
+        $sortDirection = $request->input('order', $resource->orderByDirection());
 
-        $query->when(method_exists($query, 'getQuery') && $query->getQuery()->orders, function ($query) use ($request, $resource, $sortColumn) {
-            if ($request->input('sort') && $sortColumn) {
-                $query->reorder($resource->model()->getFieldColumn($sortColumn), $request->input('order'));
-            }
-        }, fn ($query) => $query->orderBy($resource->model()->getFieldColumn($sortColumn), $request->input('order', $resource->orderByDirection())));
+        if (! $query instanceof Builder) {
+            $query->orderBy($sortColumn, $sortDirection);
+        } elseif ($request->input('sort') || empty($query->getQuery()->orders)) {
+            $query->reorder()->runwayOrderBy($sortColumn, $sortDirection);
+        }
 
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
             'resource' => $resource->handle(),

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -41,4 +41,10 @@ class ResourcePolicy
     {
         return User::fromUser($user)->hasPermission("publish {$resource->handle()}");
     }
+
+    public function reorder($user, Resource $resource)
+    {
+        return $resource->orderable()
+            && User::fromUser($user)->hasPermission("reorder {$resource->handle()}");
+    }
 }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -138,13 +138,26 @@ class Resource
         return $this->config->get('duplicatable', true);
     }
 
+    public function orderable(): bool
+    {
+        return (bool) $this->config->get('orderable', false);
+    }
+
     public function orderBy(): string
     {
+        if ($this->orderable()) {
+            return 'order';
+        }
+
         return $this->config->get('order_by', $this->primaryKey());
     }
 
     public function orderByDirection(): string
     {
+        if ($this->orderable()) {
+            return 'asc';
+        }
+
         return $this->config->get('order_by_direction', 'asc');
     }
 

--- a/src/Routing/RunwayUri.php
+++ b/src/Routing/RunwayUri.php
@@ -16,6 +16,6 @@ class RunwayUri extends Model
 
     public function getTable()
     {
-        return config('runway.uris_table', 'runway_uris');
+        return config('runway.uris_table') ?? config('runway.tables.uris', 'runway_uris');
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -147,6 +147,11 @@ class ServiceProvider extends AddonServiceProvider
                                             ->label($this->permissionLabel('publish', $resource))
                                         : null,
 
+                                    $resource->orderable()
+                                        ? Permission::make("reorder {$resource->handle()}")
+                                            ->label($this->permissionLabel('reorder', $resource))
+                                        : null,
+
                                     Permission::make("delete {$resource->handle()}")
                                         ->label($this->permissionLabel('delete', $resource)),
                                 ])),
@@ -338,6 +343,7 @@ class ServiceProvider extends AddonServiceProvider
                 'edit' => "Edit {$resource->name()}",
                 'create' => "Create {$resource->name()}",
                 'publish' => "Manage {$resource->name()} Publish State",
+                'reorder' => "Reorder {$resource->name()}",
                 'delete' => "Delete {$resource->name()}"
             };
         }

--- a/src/Structures/RunwayStructure.php
+++ b/src/Structures/RunwayStructure.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace StatamicRadPack\Runway\Structures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RunwayStructure extends Model
+{
+    protected $fillable = ['model_type', 'model_id', 'order'];
+
+    public function getTable()
+    {
+        return config('runway.tables.structures', 'runway_structures');
+    }
+
+    public static function nextOrderFor(Model $model): int
+    {
+        return static::query()->where('model_type', $model->getMorphClass())->max('order') + 1;
+    }
+}

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -124,8 +124,10 @@ class RunwayTag extends Tags
             }
 
             if ($sortColumn = OrderBy::column($sortColumn)) {
-                $query->orderBy($this->resource->model()->getFieldColumn($sortColumn), $sortDirection);
+                $query->runwayOrderBy($sortColumn, $sortDirection);
             }
+        } elseif ($this->resource->orderable()) {
+            $query->runwayOrderBy('order');
         }
 
         return $query;

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -3,6 +3,7 @@
 namespace StatamicRadPack\Runway\Traits;
 
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Contracts\Revisions\Revision;
@@ -20,7 +21,9 @@ use StatamicRadPack\Runway\Data\HasAugmentedInstance;
 use StatamicRadPack\Runway\Fieldtypes\HasManyFieldtype;
 use StatamicRadPack\Runway\Relationships;
 use StatamicRadPack\Runway\Resource;
+use StatamicRadPack\Runway\Routing\MorphOneWithStringKey;
 use StatamicRadPack\Runway\Runway;
+use StatamicRadPack\Runway\Structures\RunwayStructure;
 
 trait HasRunwayResource
 {
@@ -30,6 +33,26 @@ trait HasRunwayResource
     }
 
     public array $runwayRelationships = [];
+
+    public static function bootHasRunwayResource(): void
+    {
+        static::created(function ($model) {
+            if ($model->runwayResource()->orderable()) {
+                $model->runwayStructure()->create(['order' => RunwayStructure::nextOrderFor($model)]);
+            }
+        });
+
+        static::deleting(function ($model) {
+            if ($model->runwayResource()->orderable()) {
+                $model->runwayStructure()->delete();
+            }
+        });
+    }
+
+    public function runwayStructure(): MorphOneWithStringKey
+    {
+        return new MorphOneWithStringKey(RunwayStructure::query(), $this, 'model_type', 'model_id', $this->getKeyName());
+    }
 
     public function newAugmentedInstance(): Augmented
     {
@@ -71,6 +94,44 @@ trait HasRunwayResource
             })
             ->reject(fn (Field $field) => $field->visibility() === 'computed')
             ->each(fn (Field $field) => $query->orWhere($this->getFieldColumn($field->handle()), 'LIKE', '%'.$searchQuery.'%'));
+    }
+
+    public function scopeRunwayOrderBy(Builder $query, string $field, string $direction = 'asc'): void
+    {
+        if ($field === 'order' && $this->runwayResource()->orderable()) {
+            $this->orderByRunwayStructure($query, $direction);
+
+            return;
+        }
+
+        $query->orderBy($this->getFieldColumn($field), $direction);
+    }
+
+    private function orderByRunwayStructure(Builder $query, string $direction): void
+    {
+        $structureOrder = RunwayStructure::query()
+            ->select('order')
+            ->where('model_type', $this->getMorphClass())
+            ->whereColumn('model_id', '=', $this->keyCastToString($query))
+            ->toBase();
+
+        $query
+            ->orderByRaw("({$structureOrder->toSql()}) is null", $structureOrder->getBindings())
+            ->orderBy($structureOrder, $direction)
+            ->orderBy($this->getQualifiedKeyName());
+    }
+
+    private function keyCastToString(Builder $query): Expression
+    {
+        $key = $query->getGrammar()->wrap($this->getQualifiedKeyName());
+
+        $type = match ($query->getConnection()->getDriverName()) {
+            'pgsql', 'sqlite' => 'text',
+            'sqlsrv' => 'nvarchar(36)',
+            default => 'char',
+        };
+
+        return new Expression("cast({$key} as {$type})");
     }
 
     public function publishedStatus(): ?string

--- a/tests/HasRunwayResourceTest.php
+++ b/tests/HasRunwayResourceTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\Test;
 use StatamicRadPack\Runway\Runway;
+use StatamicRadPack\Runway\Structures\RunwayStructure;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\ExternalPost;
 use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
 
@@ -89,5 +90,41 @@ class HasRunwayResourceTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertEquals('Test External Post', $results->first()->title);
+    }
+
+    #[Test]
+    public function structure_is_created_when_model_of_orderable_resource_is_created()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+
+        Runway::discoverResources();
+
+        $posts = Post::factory()->count(3)->create();
+
+        $this->assertEquals(1, $posts[0]->runwayStructure->order);
+        $this->assertEquals(2, $posts[1]->runwayStructure->order);
+        $this->assertEquals(3, $posts[2]->runwayStructure->order);
+    }
+
+    #[Test]
+    public function structure_isnt_created_when_resource_isnt_orderable()
+    {
+        Post::factory()->count(2)->create();
+
+        $this->assertDatabaseEmpty(RunwayStructure::class);
+    }
+
+    #[Test]
+    public function structure_is_deleted_when_model_of_orderable_resource_is_deleted()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+
+        Runway::discoverResources();
+
+        $post = Post::factory()->create();
+
+        $post->delete();
+
+        $this->assertDatabaseEmpty(RunwayStructure::class);
     }
 }

--- a/tests/Http/Controllers/CP/ReorderModelsControllerTest.php
+++ b/tests/Http/Controllers/CP/ReorderModelsControllerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace StatamicRadPack\Runway\Tests\Http\Controllers\CP;
+
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blink;
+use Statamic\Facades\Role;
+use Statamic\Facades\User;
+use StatamicRadPack\Runway\Runway;
+use StatamicRadPack\Runway\Structures\RunwayStructure;
+use StatamicRadPack\Runway\Tests\Fixtures\Models\Post;
+use StatamicRadPack\Runway\Tests\TestCase;
+
+class ReorderModelsControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+
+        Runway::discoverResources();
+    }
+
+    #[Test]
+    public function can_reorder_models()
+    {
+        $user = User::make()->makeSuper()->save();
+        $posts = Post::factory()->count(3)->create();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('runway.reorder', ['resource' => 'post']), [
+                'ids' => [$posts[2]->id, $posts[0]->id, $posts[1]->id],
+                'page' => 1,
+                'perPage' => 3,
+            ])
+            ->assertOk();
+
+        $this->assertEquals(1, $this->orderOf($posts[2]));
+        $this->assertEquals(2, $this->orderOf($posts[0]));
+        $this->assertEquals(3, $this->orderOf($posts[1]));
+    }
+
+    #[Test]
+    public function can_reorder_models_on_a_later_page()
+    {
+        $user = User::make()->makeSuper()->save();
+        $posts = Post::factory()->count(4)->create();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('runway.reorder', ['resource' => 'post']), [
+                'ids' => [$posts[3]->id, $posts[2]->id],
+                'page' => 2,
+                'perPage' => 2,
+            ])
+            ->assertOk();
+
+        $this->assertEquals(1, $this->orderOf($posts[0]));
+        $this->assertEquals(2, $this->orderOf($posts[1]));
+        $this->assertEquals(3, $this->orderOf($posts[3]));
+        $this->assertEquals(4, $this->orderOf($posts[2]));
+    }
+
+    #[Test]
+    public function models_without_a_structure_are_given_one_when_reordering()
+    {
+        $user = User::make()->makeSuper()->save();
+        $posts = Post::factory()->count(3)->create();
+
+        RunwayStructure::query()->delete();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('runway.reorder', ['resource' => 'post']), [
+                'ids' => [$posts[1]->id, $posts[0]->id, $posts[2]->id],
+                'page' => 1,
+                'perPage' => 3,
+            ])
+            ->assertOk();
+
+        $this->assertEquals(1, $this->orderOf($posts[1]));
+        $this->assertEquals(2, $this->orderOf($posts[0]));
+        $this->assertEquals(3, $this->orderOf($posts[2]));
+    }
+
+    #[Test]
+    public function models_hidden_from_the_listing_are_left_alone()
+    {
+        $user = User::make()->makeSuper()->save();
+        $posts = Post::factory()->count(4)->create();
+
+        Blink::put('RunwayListingScopeWhereIn', [$posts[0]->id, $posts[2]->id, $posts[3]->id]);
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('runway.reorder', ['resource' => 'post']), [
+                'ids' => [$posts[3]->id, $posts[0]->id, $posts[2]->id],
+                'page' => 1,
+                'perPage' => 3,
+            ])
+            ->assertOk();
+
+        $this->assertEquals(1, $this->orderOf($posts[3]));
+        $this->assertEquals(2, $this->orderOf($posts[0]));
+        $this->assertEquals(3, $this->orderOf($posts[2]));
+        $this->assertEquals(2, $this->orderOf($posts[1]));
+    }
+
+    #[Test]
+    public function cant_reorder_models_when_listing_is_out_of_date()
+    {
+        $user = User::make()->makeSuper()->save();
+        $posts = Post::factory()->count(3)->create();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('runway.reorder', ['resource' => 'post']), [
+                'ids' => [$posts[1]->id, $posts[0]->id],
+                'page' => 1,
+                'perPage' => 3,
+            ])
+            ->assertStatus(409);
+
+        $this->assertEquals(1, $this->orderOf($posts[0]));
+        $this->assertEquals(2, $this->orderOf($posts[1]));
+        $this->assertEquals(3, $this->orderOf($posts[2]));
+    }
+
+    #[Test]
+    public function cant_reorder_models_without_ids_page_and_per_page()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('runway.reorder', ['resource' => 'post']), [])
+            ->assertJsonValidationErrors(['ids', 'page', 'perPage']);
+    }
+
+    #[Test]
+    public function cant_reorder_models_when_resource_isnt_orderable()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('runway.reorder', ['resource' => 'author']), [
+                'ids' => [],
+                'page' => 1,
+                'perPage' => 3,
+            ])
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function user_without_permission_cant_reorder_models()
+    {
+        Role::make('test')->addPermission('edit post')->save();
+        $user = User::make()->assignRole('test')->save();
+        $posts = Post::factory()->count(2)->create();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('runway.reorder', ['resource' => 'post']), [
+                'ids' => [$posts[1]->id, $posts[0]->id],
+                'page' => 1,
+                'perPage' => 2,
+            ])
+            ->assertForbidden();
+    }
+
+    private function orderOf(Post $post): ?int
+    {
+        return $post->runwayStructure()->value('order');
+    }
+}

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -35,6 +35,31 @@ class ResourceControllerTest extends TestCase
                 ->has('actionUrl')
                 ->has('sortColumn')
                 ->has('sortDirection')
+                ->where('reorderable', false)
+                ->has('reorderUrl')
+            );
+    }
+
+    #[Test]
+    public function model_index_is_reorderable_when_resource_is_orderable()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+
+        Runway::discoverResources();
+
+        Post::factory()->count(2)->create();
+        $user = User::make()->makeSuper()->save();
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('runway.index', ['resource' => 'post']))
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('runway::Index')
+                ->where('sortColumn', 'order')
+                ->where('sortDirection', 'asc')
+                ->where('reorderable', true)
+                ->where('reorderUrl', 'http://localhost/cp/runway/post/reorder')
             );
     }
 

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -85,6 +85,58 @@ class ResourceListingControllerTest extends TestCase
     }
 
     #[Test]
+    public function listing_rows_are_ordered_by_structure_when_resource_is_orderable()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+
+        Runway::discoverResources();
+
+        $user = User::make()->makeSuper()->save();
+        $posts = Post::factory()->count(3)->create();
+
+        $posts[0]->runwayStructure()->update(['order' => 2]);
+        $posts[1]->runwayStructure()->update(['order' => 1]);
+        $posts[2]->runwayStructure()->delete();
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('runway.listing-api', ['resource' => 'post']))
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    ['id' => $posts[1]->id],
+                    ['id' => $posts[0]->id],
+                    ['id' => $posts[2]->id],
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function listing_rows_can_be_sorted_by_order_when_resource_is_orderable()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+
+        Runway::discoverResources();
+
+        $user = User::make()->makeSuper()->save();
+        $posts = Post::factory()->count(3)->create();
+
+        Blink::put('RunwayListingScopeOrderBy', ['id', 'desc']);
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('runway.listing-api', ['resource' => 'post', 'sort' => 'order', 'order' => 'asc']))
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    ['id' => $posts[0]->id],
+                    ['id' => $posts[1]->id],
+                    ['id' => $posts[2]->id],
+                ],
+            ]);
+    }
+
+    #[Test]
     public function listing_rows_are_ordered_from_runway_listing_scope()
     {
         $user = User::make()->makeSuper()->save();

--- a/tests/Policies/ResourcePolicyTest.php
+++ b/tests/Policies/ResourcePolicyTest.php
@@ -2,6 +2,7 @@
 
 namespace StatamicRadPack\Runway\Tests\Policies;
 
+use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Role;
 use Statamic\Facades\User;
@@ -106,5 +107,46 @@ class ResourcePolicyTest extends TestCase
         $user = User::make()->assignRole('test')->save();
 
         $this->assertTrue($user->can('delete', [$resource, new Post]));
+    }
+
+    #[Test]
+    public function can_reorder_resource()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('reorder post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertTrue($user->can('reorder', $resource));
+    }
+
+    #[Test]
+    public function cant_reorder_resource_without_permission()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('edit post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertFalse($user->can('reorder', $resource));
+    }
+
+    #[Test]
+    public function cant_reorder_resource_when_resource_isnt_orderable()
+    {
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('reorder post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertFalse($user->can('reorder', $resource));
     }
 }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -337,4 +337,29 @@ class ResourceTest extends TestCase
 
         $this->assertFalse($resource->revisionsEnabled());
     }
+
+    #[Test]
+    public function orderable_resource_is_ordered_by_order_ascending()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.order_by', 'title');
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.order_by_direction', 'desc');
+
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        $this->assertTrue($resource->orderable());
+        $this->assertEquals('order', $resource->orderBy());
+        $this->assertEquals('asc', $resource->orderByDirection());
+    }
+
+    #[Test]
+    public function resource_isnt_orderable_by_default()
+    {
+        $resource = Runway::findResource('post');
+
+        $this->assertFalse($resource->orderable());
+        $this->assertEquals('id', $resource->orderBy());
+    }
 }

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -305,6 +305,47 @@ class RunwayTagTest extends TestCase
     }
 
     #[Test]
+    public function models_are_ordered_by_structure_when_resource_is_orderable()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+
+        Runway::discoverResources();
+
+        $posts = Post::factory()->count(3)->create();
+
+        $posts[0]->runwayStructure()->update(['order' => 3]);
+        $posts[2]->runwayStructure()->update(['order' => 1]);
+
+        $this->tag->setParameters([]);
+
+        $usage = $this->tag->wildcard('post');
+
+        $this->assertEquals($posts[2]->id, $usage[0]['id']->value());
+        $this->assertEquals($posts[1]->id, $usage[1]['id']->value());
+        $this->assertEquals($posts[0]->id, $usage[2]['id']->value());
+    }
+
+    #[Test]
+    public function can_get_models_with_sort_parameter_on_order()
+    {
+        Config::set('runway.resources.StatamicRadPack\Runway\Tests\Fixtures\Models\Post.orderable', true);
+
+        Runway::discoverResources();
+
+        $posts = Post::factory()->count(3)->create();
+
+        $this->tag->setParameters([
+            'sort' => 'order:desc',
+        ]);
+
+        $usage = $this->tag->wildcard('post');
+
+        $this->assertEquals($posts[2]->id, $usage[0]['id']->value());
+        $this->assertEquals($posts[1]->id, $usage[1]['id']->value());
+        $this->assertEquals($posts[0]->id, $usage[2]['id']->value());
+    }
+
+    #[Test]
     public function can_get_models_with_scoping()
     {
         $posts = Post::factory()->count(2)->create();

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -48,6 +48,10 @@ class Post extends Model
         if ($params = Blink::get('RunwayListingScopeOrderBy')) {
             $query->orderBy($params[0], $params[1]);
         }
+
+        if ($ids = Blink::get('RunwayListingScopeWhereIn')) {
+            $query->whereIn('id', $ids);
+        }
     }
 
     public function author()


### PR DESCRIPTION
This pull request implements "orderable" resources, which lets users drag & drop models into a manual order in the Control Panel listing, just like an orderable collection.

https://github.com/user-attachments/assets/031eade1-c76c-4162-acd0-3de140d57a77

To enable it, add `'orderable' => true` to a resource's config:

```php
'resources' => [
    \App\Models\Manufacturer::class => [
        'orderable' => true,
    ],
],
```

## How the order is stored

Runway keeps track of the order in its own `runway_structures` table, so you don't need to add a column to your model's table. There's a migration for it, so you'll need to run `php artisan migrate` after updating.

A structure row is created when a model is created (placed at the end), and removed when the model is deleted. Models which don't have a structure row yet (eg. models created before the resource was made orderable) are placed at the end until the order is next saved.

When a resource is orderable, the `order_by` and `order_by_direction` options are ignored.

## Reordering

The listing gets a "Reorder" button which enables drag & drop on the table, with `mod+s` to save. Reordering works page by page, like it does for entries. Saving posts to a new `runway/{resource}/reorder` endpoint, handled by `ReorderModelsController`, which is modelled on core's `ReorderEntriesController`. If the listing is out of date when saving, a `409` is returned and the user is asked to refresh.

Users need the new "Reorder" permission for the resource, which is only shown for orderable resources.

## Sorting by `order`

Models are returned in the manual order by the Control Panel listing, the relationship fieldtypes, the `{{ runway }}` tag and the GraphQL API. You can also sort by `order` explicitly:

```antlers
{{ runway:manufacturer sort="order:desc" }}
```

Under the hood, this adds a `runwayOrderBy` query scope to `HasRunwayResource`. It resolves the virtual `order` field to a subquery on the structures table and passes everything else through to `getFieldColumn()`, so all of the places that sort use the same code path.

The GraphQL index query now defaults to the resource's `order_by` / `order_by_direction` rather than a hardcoded `id`.

## `tables` config option

This PR also replaces the `uris_table` config option with a `tables` array, so each of Runway's tables can be renamed in one place:

```php
'tables' => [
    'uris' => 'runway_uris',
    'structures' => 'runway_structures',
],
```

The old `uris_table` key is still respected, so existing config files don't need to be changed.

---

Related: #631
